### PR TITLE
COMDOX-588: Standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,37 @@
-# Adobe I/O Documentation Template
+# Adobe Commerce Extensibility Developer Documentation
 
-This is a site template built with the [Adobe I/O Theme](https://github.com/adobe/aio-theme).
+Welcome! This site contains the latest Adobe Commerce extensibility developer documentation for ongoing releases.
 
-View the [demo](https://adobedocs.github.io/dev-site-documentation-template/) running on Github Pages.  
+## Local development
 
-## Where to ask for help
+This is a [Gatsby](https://www.gatsbyjs.com/) project that uses the [Adobe I/O Theme](https://github.com/adobe/aio-theme).
 
-The slack channel #adobeio-onsite-onboarding is our main point of contact for help. Feel free to join the channel and ask any questions.
+To build the site locally:
 
-## How to develop
+1. Clone this repo.
+1. Install project dependencies.
 
-For local development, simply use :
+   ```bash
+   yarn install
+   ```
 
-```shell
-$ yarn install
-$ yarn dev
-```
+1. Launch the project in development mode.
 
-For the developer documentation, read the following sections on how to:
+   ```bash
+   yarn dev
+   ```
 
-- [Arrange the structure content of your docs](https://github.com/adobe/aio-theme#content-structure)
-- [Link to pages](https://github.com/adobe/aio-theme#links)
-- [Use assets](https://github.com/adobe/aio-theme#assets)
-- [Set global Navigation](https://github.com/adobe/aio-theme#global-navigation)
-- [Set side navigation](https://github.com/adobe/aio-theme#side-navigation)
-- [Use content blocks](https://github.com/adobe/aio-theme#jsx-blocks)
-- [Use Markdown](https://github.com/adobe/aio-theme#writing-enhanced-markdown)
+## Resources
 
-For more in-depth [instructions](https://github.com/adobe/aio-theme#getting-started).
+See the following resources to learn more about using the theme:
 
-## How to test
+- [Arranging content structure](https://github.com/adobe/aio-theme#content-structure)
+- [Linking to pages](https://github.com/adobe/aio-theme#links)
+- [Using assets](https://github.com/adobe/aio-theme#assets)
+- [Configuring global navigation](https://github.com/adobe/aio-theme#global-navigation)
+- [Configuring side navigation](https://github.com/adobe/aio-theme#side-navigation)
+- [Using content blocks](https://github.com/adobe/aio-theme#jsx-blocks)
+- [Writing enhanced Markdown](https://github.com/adobe/aio-theme#writing-enhanced-markdown)
+- [Deploying the site](https://github.com/adobe/aio-theme#deploy-to-azure-storage-static-websites) _(Adobe employees only)_
 
-- To run the configured linters locally (requires [Docker](https://www.docker.com/)):
-
-  ```shell
-  yarn lint
-  ```
-
-  > NOTE If you cannot use Docker, you can install the linters separately. In `.github/super-linter.env`, see which linters are enabled, and find the tools being used for linting in [Supported Linters](https://github.com/github/super-linter#supported-linters).
-
-- To check internal links locally
-
-  ```shell
-  yarn test:links
-  ```
-
-- To build and preview locally:
-
-  ```shell
-  yarn start
-  ```
-
-## How to deploy
-
-For any team that wishes to deploy to the developer.adobe.com and developer-stage.adobe.com websites, they must be in contact with the dev-site team. Teams will be given a path that will follow the pattern `developer.adobe.com/{product}/`. This will allow doc developers to setup their subpaths to look something like:
-
-```text
-developer.adobe.com/{product}/docs
-developer.adobe.com/{product}/community
-developer.adobe.com/{product}/community/code_of_conduct
-developer.adobe.com/{product}/community/contribute
-```
-
-### Launching a deploy
-
-You can deploy using the GitHub actions deploy workflow see [deploy instructions](https://github.com/adobe/aio-theme#deploy-to-azure-storage-static-websites).
+If you have questions, open an issue and ask us. We look forward to hearing from you!


### PR DESCRIPTION
This pull request (PR) standardizes the README using the [magento/devdocs](https://github.com/magento/devdocs/blob/master/README.md?plain=1) repo as a baseline. The goal is to have a standard README that can be used across all [`commerce-*`](https://github.com/topics/adobe-commerce-devsite) devsite repos and add repo-specific info if necessary (e.g., generating API reference, rendering templates).

This README differs slightly from other `commerce-*` repos because the docs are for Adobe Commerce only.