### PR TITLE
COMDOX-596: Update gatsby-theme-aio to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/icaraps"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.8.4",
+    "@adobe/gatsby-theme-aio": "^4.9.0",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,9 +33,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/gatsby-theme-aio@npm:^4.8.4":
-  version: 4.8.4
-  resolution: "@adobe/gatsby-theme-aio@npm:4.8.4"
+"@adobe/gatsby-theme-aio@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "@adobe/gatsby-theme-aio@npm:4.9.0"
   dependencies:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
@@ -125,7 +125,7 @@ __metadata:
     gatsby: ^4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 01d0f3cf34a5c005561cd8ca46da5ebec0ef0e9a1f121723a352ee1e8fff13aaecae1b5465aa1c32c37da912f15d5dbaf30dddc5c48c5aa3b0dc19d93b09b68a
+  checksum: 533ca043b9b1d61b638f6fb6118e9b3e667a1285fe903f50d88cdc999c5bf6502de827541afc2f219d7c30b869680b1722d4187ebbdcea190385c2a83ae1c21a
   languageName: node
   linkType: hard
 
@@ -7732,7 +7732,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dev-site-documentation-template@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.8.4
+    "@adobe/gatsby-theme-aio": ^4.9.0
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the `gatsby-theme-aio` dependency to the latest version ([`4.9.0`](https://github.com/adobe/aio-theme/releases/tag/@adobe/gatsby-theme-aio@4.9.0)).

**Staging:** _Newly provisioned repo. No production site deployed. Staging build unnecessary._