### PR TITLE
Add stub files and navigation for SDK and ASC docs

### DIFF
--- a/src/data/navigation/header.js
+++ b/src/data/navigation/header.js
@@ -4,7 +4,11 @@ module.exports = [
       path: "/",
     },
     {
-      title: "BackOffice SDK",
-      path: "/backoffice/",
+      title: "Admin UI SDK",
+      path: "/admin-ui-sdk/",
     },
+    {
+      title: "Amazon Sales Channel",
+      path: "/amazon-sales-channel/"
+    }
   ];

--- a/src/data/navigation/sections/admin-ui-sdk.js
+++ b/src/data/navigation/sections/admin-ui-sdk.js
@@ -1,0 +1,30 @@
+module.exports = [
+    {
+      title: "Overview",
+      path: "/admin-ui-sdk/index.md"
+    },
+    {
+      title: "Installation",
+      path: "/admin-ui-sdk/installation.md"
+    },
+    {
+      title: "Admin configuration and testing",
+      path: "/admin-ui-sdk/configuration.md"
+    },
+    {
+      title: "App development",
+      path: "/admin-ui-sdk/app-development.md"
+    },
+    {
+      title: "MenuApp component",
+      path: "/admin-ui-sdk/reference/menu-app.md"
+    },
+    {
+      title: "PageApp component",
+      path: "/admin-ui-sdk/reference/page-app.md"
+    },
+    {
+      title: "Release notes",
+      path: "/admin-ui-sdk/release-notes.md"
+    }
+  ];

--- a/src/data/navigation/sections/amazon-sales-channel.js
+++ b/src/data/navigation/sections/amazon-sales-channel.js
@@ -1,0 +1,18 @@
+module.exports = [
+    {
+        title: "Overview",
+        path: "/amazon-sales-channel/index.md",
+    },
+    {
+        title: "Installation",
+        path: "/amazon-sales-channel/installation.md",
+    },
+    {
+        title: "Best Practices",
+        path: "/amazon-sales-channel/best-practices/index.md",
+    },
+    {
+        title: "Release Notes",
+        path: "/amazon-sales-channel/release-notes.md"
+    }
+  ];

--- a/src/data/navigation/sections/backoffice.js
+++ b/src/data/navigation/sections/backoffice.js
@@ -1,6 +1,0 @@
-module.exports = [
-    {
-      title: "Overview",
-      path: "/backoffice/index.md"
-    },
-  ];

--- a/src/data/navigation/sections/index.js
+++ b/src/data/navigation/sections/index.js
@@ -1,4 +1,4 @@
-const backoffice = require("./backoffice");
-const events = require("./backoffice");
+const adminuisdk = require("./admin-ui-sdk");
+const amazon = require("./amazon-sales-channel");
 
-module.exports = [...backoffice];
+module.exports = [...adminuisdk, ...amazon];

--- a/src/pages/admin-ui-sdk/app-development.md
+++ b/src/pages/admin-ui-sdk/app-development.md
@@ -1,0 +1,6 @@
+---
+title: App development
+description: 
+---
+
+# App development

--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -1,0 +1,6 @@
+---
+title: Admin configuration and testing
+description: 
+---
+
+# Admin configuration and testing

--- a/src/pages/admin-ui-sdk/index.md
+++ b/src/pages/admin-ui-sdk/index.md
@@ -1,0 +1,6 @@
+---
+title: Adobe Commerce Admin UI SDK overview
+description: An architectural overview of the Adobe Commerce Admin UI SDK
+---
+
+# Adobe Commerce Admin UI SDK overview

--- a/src/pages/admin-ui-sdk/installation.md
+++ b/src/pages/admin-ui-sdk/installation.md
@@ -1,0 +1,6 @@
+---
+title: Installation
+description: 
+---
+
+# Installation

--- a/src/pages/admin-ui-sdk/reference/menu-app.md
+++ b/src/pages/admin-ui-sdk/reference/menu-app.md
@@ -1,0 +1,6 @@
+---
+title: MenuApp component
+description: 
+---
+
+# MenuApp component

--- a/src/pages/admin-ui-sdk/reference/page-app.md
+++ b/src/pages/admin-ui-sdk/reference/page-app.md
@@ -1,0 +1,6 @@
+---
+title: PageApp component
+description: 
+---
+
+# PageApp component

--- a/src/pages/admin-ui-sdk/release-notes.md
+++ b/src/pages/admin-ui-sdk/release-notes.md
@@ -1,0 +1,6 @@
+---
+title: Release notes
+description: 
+---
+
+# Release notes

--- a/src/pages/amazon-sales-channel/best-practices/index.md
+++ b/src/pages/amazon-sales-channel/best-practices/index.md
@@ -1,0 +1,6 @@
+---
+title: Best practices overview
+description: 
+---
+
+# Best practices overview

--- a/src/pages/amazon-sales-channel/index.md
+++ b/src/pages/amazon-sales-channel/index.md
@@ -1,0 +1,6 @@
+---
+title: Amazon Sales Channel reference app overview
+description: 
+---
+
+# Amazon Sales Channel reference app overview

--- a/src/pages/amazon-sales-channel/installation.md
+++ b/src/pages/amazon-sales-channel/installation.md
@@ -1,0 +1,6 @@
+---
+title: Installation
+description: 
+---
+
+# Installation

--- a/src/pages/amazon-sales-channel/release-notes.md
+++ b/src/pages/amazon-sales-channel/release-notes.md
@@ -1,0 +1,6 @@
+---
+title: Release notes
+description: 
+---
+
+# Release notes

--- a/src/pages/backoffice/index.md
+++ b/src/pages/backoffice/index.md
@@ -1,6 +1,0 @@
----
-title: Adobe Commerce BackOffice SDK Overview
-description: An architectural overview of the Adobe Commerce BackOffice SDK
----
-
-# Adobe Commerce BackOffice SDK Overview


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds stub files and top/left navigation for Admin UI SDK and Amazon Sales Channel app guides. I'm doing this now to remove barriers for developer contributions.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
