### PR TITLE
Add relnotes for ASC and Admin UI SDK

### DIFF
--- a/src/pages/admin-ui-sdk/release-notes.md
+++ b/src/pages/admin-ui-sdk/release-notes.md
@@ -1,6 +1,22 @@
 ---
 title: Release notes
-description: 
+description: This page lists new features and known issues for each release of Adobe Commerce Admin UI SDKVersion 1.0.0
 ---
 
 # Release notes
+
+## Version 1.0.0
+
+### Release date
+
+June 13, 2023
+
+### Compatibility
+
+Adobe Commerce for Cloud and on-premises
+
+*  2.4.5 and higher
+
+### Known issues
+
+None

--- a/src/pages/amazon-sales-channel/release-notes.md
+++ b/src/pages/amazon-sales-channel/release-notes.md
@@ -1,6 +1,24 @@
 ---
 title: Release notes
-description: 
+description: This page lists new features and known issues for each release of Amazon Sales Channel on App Builder 1.0.0
 ---
 
 # Release notes
+
+## Version 1.0.0
+
+### Release date
+
+June 13, 2023
+
+### Compatibility
+
+Adobe Commerce for Cloud and on-premises
+
+*  2.4.5 and higher
+
+### Known limitations
+
+Amazon Sales Channel on App Builder is a reference app that demonstrates how Adobe Developer App Builder can create integrations and extensions without modifying the core Commerce application. This app is not intended or supported for production use.
+
+The sample app functionality represents only a subset of the original PHP extension's capabilities. For example, it does not feature order management, listing and pricing rules.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for the Amazon Sales Channel reference app and the Admin UI SDK.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
