### PR TITLE
CEXT-2057: Fix the server.js URL in the response JSON

### DIFF
--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -88,7 +88,7 @@ You can download a sample app from the [Commerce UI test extension repository](h
           "endpoints": {
             "commerce/backend-ui/1": {
               "view": [{
-                "href": "https://localhost:9080/"
+                "href": "https://localhost:9080/index.html"
               }]
             }
           },


### PR DESCRIPTION
## Purpose of this pull request

The published documentation contains a server.js code that has an incorrect URL. This PR corrects this so users can correctly install and work with the Admin UI SDK locally.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
