### PR TITLE
Fix composer require backend-uix command

### DIFF
--- a/src/pages/admin-ui-sdk/installation.md
+++ b/src/pages/admin-ui-sdk/installation.md
@@ -40,7 +40,7 @@ This method installs the SDK on a cloud instance.
 1. Update your `composer.json` file:
 
    ```bash
-   composer require magento/module-commerce-backend-uix": ">=1.0
+   composer require "magento/module-commerce-backend-uix": ">=1.0"
    ```
 
 1. Update dependencies and install the extension:

--- a/src/pages/admin-ui-sdk/installation.md
+++ b/src/pages/admin-ui-sdk/installation.md
@@ -64,7 +64,7 @@ This method installs the SDK on an On-premises instance.
 1. Add the SDK module to the `require` section of the `composer.json` file:
 
    ```bash
-   composer require magento/module-commerce-backend-uix": ">=1.0
+   composer require "magento/module-commerce-backend-uix": ">=1.0"
    ```
 
 1. Update dependencies and install the extension:


### PR DESCRIPTION
## Purpose of this pull request

Fix composer require command due to some missing double commas

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [Install Adobe Commerce Admin UI SDK
](https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/installation/#adobe-commerce-on-cloud-infrastructure)


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
