### PR TITLE
Clarify frontend development details

### DIFF
--- a/src/pages/app-development/index.md
+++ b/src/pages/app-development/index.md
@@ -25,7 +25,11 @@ Once you've become comfortable with the Adobe I/O infrastructure, analyze  your 
 
 ### Frontend development
 
-[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. Adobe Commerce continues support of legacy [PWA Studio](https://developer.adobe.com/commerce/pwa-studio/) and [Luma](https://developer.adobe.com/commerce/frontend-core/) storefronts.
+[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps that match the look and feel of the Adobe Commerce Admin.
+
+<InlineAlert variant="info" slots="text"/>
+
+Adobe Commerce continues to support the [PWA Studio](https://developer.adobe.com/commerce/pwa-studio/) and [Luma](https://developer.adobe.com/commerce/frontend-core/) storefronts.
 
 ### APIs
 

--- a/src/pages/app-development/index.md
+++ b/src/pages/app-development/index.md
@@ -25,7 +25,7 @@ Once you've become comfortable with the Adobe I/O infrastructure, analyze  your 
 
 ### Frontend development
 
-[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps that match the look and feel of the Adobe Commerce Admin.
+[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps that match the look and feel of the Adobe Commerce Admin. See [Admin UI SDK](#admin-development).
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/app-development/index.md
+++ b/src/pages/app-development/index.md
@@ -25,7 +25,7 @@ Once you've become comfortable with the Adobe I/O infrastructure, analyze  your 
 
 ### Frontend development
 
-[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps that match the look and feel of the Adobe Commerce Admin. See [Admin UI SDK](#admin-development).
+[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps consistent with Adobe standards and leverage our SDK (#admin-development) to securely create custom app UIs in the Adobe Commerce Admin.
 
 <InlineAlert variant="info" slots="text"/>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) clarifies the details about frontend development (per request from PMM) to make sure developers know that Spectrum can be used to build apps with the same look and feel of the Admin. 

The original text might be misinterpreted by some to mean that App Builder can be used as the storefront. At present, it cannot.

## Affected pages

- https://developer.adobe.com/commerce/extensibility/app-development/#frontend-development