### PR TITLE
Create stubs for commands

### DIFF
--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -6,3 +6,147 @@ keywords:
 ---
 
 # Webhooks commands
+
+## Display the payload of a webhook
+
+The `webhooks:info` command returns the payload of the specified webhook. You can optionally specify the depth of the payload to reduce the amount data returned.
+### Usage
+
+`bin/magento webhooks:info <webhook-name> [--webhook-type=`before` | `after`] [--depth=<integer>]`
+
+### Arguments
+
+`webhook-name` Required.
+
+`--webhook-type` Optional.
+
+### Options
+
+`--depth=<integer>` Determines how many nested levels of the payload to return. The default value is `?`.
+
+### Example
+
+```bash
+
+```
+
+### Response
+
+```terminal
+
+```
+
+## Return a list of supported webhook event names
+
+The `webhooks:list:all` command returns a list of events defined in the specified module that can be used as the trigger for a webhook. 
+
+### Usage
+
+`bin/magento webhooks:list:all <module_name>`
+
+### Arguments
+
+`<module_name>` Required. Specifies the module to query.
+
+### Example
+
+```bash
+bin/magento webhooks:list:all Magento_Sales
+```
+
+### Response
+
+```terminal
+observer.admin_sales_order_address_update
+observer.adminhtml_customer_orders_add_action_renderer
+observer.adminhtml_sales_order_create_process_data
+observer.adminhtml_sales_order_create_process_data_before
+observer.adminhtml_sales_order_create_process_item_after
+...
+plugin.magento.sales.api.creditmemo_comment_repository.delete
+plugin.magento.sales.api.creditmemo_comment_repository.save
+plugin.magento.sales.api.creditmemo_item_repository.delete
+plugin.magento.sales.api.creditmemo_item_repository.save
+plugin.magento.sales.api.creditmemo_management.cancel
+...
+```
+
+## Return a list of subscribed webhooks
+
+The `webhooks:list` command returns details about all subscribed webhooks. The response contains the webhook name and the type of plugin that calls the webhook, (`before` or `after`). The batch column of the response contains a list of hooks that can be executed in parallel.
+
+### Usage
+
+`bin/magento webhooks:list`
+
+### Example
+
+```bash
+bin/magento webhooks:list
+```
+
+### Response
+
+```terminal
+ok | 10:25:24 AM
++-------------------------------------------+--------+---------------------------------------------------------------------------+
+| name                                      | type   | batches                                                                   |
++-------------------------------------------+--------+---------------------------------------------------------------------------+
+| observer.catalog_product_save_after       | after  | [                                                                         |
+|                                           |        |     [                                                                     |
+|                                           |        |         {                                                                 |
+|                                           |        |             "name": "product_updated",                                    |
+|                                           |        |             "url": "{env:APP_BUILDER_PROJECT_URL}\/product-updated",      |
+|                                           |        |             "method": "",                                                 |
+|                                           |        |             "headers": [                                                  |
+|                                           |        |                 "x-gw-ims-org-id : {env:APP_BUILDER_IMS_ORG_ID}",         |
+|                                           |        |                 "Authorization : Bearer {env:APP_BUILDER_AUTH_TOKEN}",    |
+|                                           |        |                 "Magento\\WebhookModule\\Model\\AddProductToCartResolver" |
+|                                           |        |             ],                                                            |
+|                                           |        |             "fields": [                                                   |
+|                                           |        |                 "product.name : data.product.name",                       |
+|                                           |        |                 "product.category_ids : data.product.category_ids",       |
+|                                           |        |                 "product.sku : data.product.sku"                          |
+|                                           |        |             ]                                                             |
+|                                           |        |         }                                                                 |
+|                                           |        |     ]                                                                     |
+|                                           |        | ]                                                                         |
+| observer.checkout_cart_product_add_before | before | [                                                                         |
+|                                           |        |     [                                                                     |
+|                                           |        |         {                                                                 |
+|                                           |        |             "name": "validate_stock",                                     |
+|                                           |        |             "url": "http:\/\/localhost:8085\/product-validate-stock",     |
+|                                           |        |             "method": "",                                                 |
+|                                           |        |             "headers": [                                                  |
+|                                           |        |                 "Magento\\WebhookModule\\Model\\AddProductToCartResolver" |
+|                                           |        |             ],                                                            |
+|                                           |        |             "fields": [                                                   |
+|                                           |        |                 "product.name : data.product.name",                       |
+|                                           |        |                 "product.category_ids : data.product.category_ids",       |
+|                                           |        |                 "product.sku : data.product.sku"                          |
+|                                           |        |             ]                                                             |
+|                                           |        |         }                                                                 |
+|                                           |        |     ]                                                                     |
+|                                           |        | ]                                                                         |
++-------------------------------------------+--------+---------------------------------------------------------------------------+
+```
+
+## Generate plugins
+
+The `webhooks:generate:module` command generates plugins based on webhook registrations and places it into the Commerce `app/code/Magento` directory.
+
+### Usage
+
+`bin/magento webhooks:generate:module`
+
+### Example
+
+```bash
+bin/magento webhooks:generate:module
+```
+
+### Response
+
+```terminal
+Module was generated in the app/code/Magento directory
+```

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -10,6 +10,7 @@ keywords:
 ## Display the payload of a webhook
 
 The `webhooks:info` command returns the payload of the specified webhook. You can optionally specify the depth of the payload to reduce the amount data returned.
+
 ### Usage
 
 `bin/magento webhooks:info <webhook-name> [--webhook-type=`before` | `after`] [--depth=<integer>]`
@@ -38,7 +39,7 @@ The `webhooks:info` command returns the payload of the specified webhook. You ca
 
 ## Return a list of supported webhook event names
 
-The `webhooks:list:all` command returns a list of events defined in the specified module that can be used as the trigger for a webhook. 
+The `webhooks:list:all` command returns a list of events defined in the specified module that can be used as the trigger for a webhook.
 
 ### Usage
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) creates stubs for each command certain to be in the initial release of Webhooks.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
