### PR TITLE
Fix community engineering slack channel link

### DIFF
--- a/src/pages/amazon-sales-channel/index.md
+++ b/src/pages/amazon-sales-channel/index.md
@@ -40,6 +40,6 @@ In general, the sample app looks and feels like the PHP extension. However, some
 
 ## Additional resources
 
-* Join the [#app-builder-community slack channel](https://github.com/AdobeDocs/commerce-extensibility/pull/49/magentocommeng.slack.com) in the Commerce Engineering Slack workspace to ask questions directly to teams and partners working with App Builder.
+* Join the [#app-builder-community slack channel](https://magentocommeng.slack.com/archives/C04KT43Q75K) in the Commerce Engineering Slack workspace to ask questions directly to teams and partners working with App Builder.
 
 * Review [Common Troubleshooting](https://developer.adobe.com/app-builder/docs/getting_started/common_troubleshooting/) in the App Builder _Getting Started_ guide for the latest debugging tips.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes community engineering slack channel link.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
