### PR TITLE
CEXT-2387: Update webhooks:dev:run command

### DIFF
--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -313,7 +313,7 @@ For example, you have registered the next webhook:
     </method>
 ```
 
-Instead of trying to add the product to the cart through the Adobe Commerce UI, you can run the next command with custom payload:
+Instead pf manually adding a product to the cart from the storefront, you can run the following command, which specifies a custom payload:
 
 `bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'`
 

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -292,7 +292,7 @@ Run this command after setting the initial webhook payload in a `webhooks.xml` f
 
 &lt;webhook-name:type> Required. The combination of webhook name and type. The name must begin with either `observer.` or `plugin.`. The `type` must be either `before` or `after`. Example: `observer.checkout_cart_product_add_before:before`
 
-&lt;webhook-arguments-payload> Required. The webhook arguments payload in JSON format. The payload will be filtered according to the `fields` rules before being sent to the webhook endpoint. This emulates how the real arguments will be filtered in the generated plugin for the webhool.
+&lt;webhook-arguments-payload> Required. The webhook arguments payload in JSON format. The payload will be filtered according to the `fields` rules defined in a `webhooks.xml` file before being sent to the webhook endpoint. This emulates how the real arguments will be filtered in the generated plugin for the webhook.
 
 ### Example
 

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -325,7 +325,7 @@ The webhook endpoint will receive the next payload according to `fields` configu
 
 In case of error or returning the exception operation you will see the appropriate information in the command output
 
-```
+```bash
 Failed to process webhook "observer.checkout_cart_product_add_before". Or webhook endpoint returned exception operation. Error: Webhook Response: The product is out of stock
 Check logs for more information.
 ```

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -315,6 +315,7 @@ For example, you have registered the next webhook:
 
 Instead pf manually adding a product to the cart from the storefront, you can run the following command, which specifies a custom payload:
 
+```bash
 `bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'`
 
 The webhook endpoint will receive the next payload according to `fields` configured for the webhook:

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -296,7 +296,7 @@ Run this command after setting the initial webhook payload in a `webhooks.xml` f
 
 ### Example
 
-For example, you have registered the next webhook:
+The webhooks.xml file registered the following webhook:
 
 ```xml
     <method name="observer.checkout_cart_product_add_before" type="before">
@@ -313,7 +313,7 @@ For example, you have registered the next webhook:
     </method>
 ```
 
-Instead pf manually adding a product to the cart from the storefront, you can run the following command, which specifies a custom payload:
+Instead of manually adding a product to the cart from the storefront, you can run the following command, which specifies a custom payload:
 
 ```bash
 bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -316,7 +316,7 @@ For example, you have registered the next webhook:
 Instead pf manually adding a product to the cart from the storefront, you can run the following command, which specifies a custom payload:
 
 ```bash
-`bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'`
+bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'
 
 The webhook endpoint will receive the next payload according to `fields` configured for the webhook:
 

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -281,7 +281,7 @@ Module was generated in the app/code/Magento directory
 
 ## Emulate webhook execution
 
-The `webhooks:dev:run` is used for developing purposes only. It can emulate the execution of your registered webhook with a custom payload.
+The `webhooks:dev:run` command is used for development and testing purposes only. It emulates the execution of your registered webhook containing a custom payload with requiring changes to the Commerce application. 
 This can be helpful during the development or testing of the webhook endpoint as you can emulate webhook execution with different payloads without making required changes in the Adobe Commerce application to trigger webhook execution.
 
 ### Usage

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -290,7 +290,7 @@ Run this command after setting the initial webhook payload in a `webhooks.xml` f
 
 ### Arguments
 
-&lt;webhook-name> Required. The combination of webhook name and type, the name must begin with either `observer.` or `plugin.`. Example: `observer.checkout_cart_product_add_before:before`
+&lt;webhook-name:type> Required. The combination of webhook name and type. The name must begin with either `observer.` or `plugin.`. The `type` must be either `before` or `after`. Example: `observer.checkout_cart_product_add_before:before`
 
 &lt;webhook-arguments-payload> Required. The webhook arguments payload in JSON format. The payload will be filtered according to the `fields` rules before being sent to the webhook endpoint. This emulates how the real arguments will be filtered in the generated plugin for the webhool.
 

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -282,7 +282,7 @@ Module was generated in the app/code/Magento directory
 ## Emulate webhook execution
 
 The `webhooks:dev:run` command is used for development and testing purposes only. It emulates the execution of your registered webhook containing a custom payload with requiring changes to the Commerce application. 
-This can be helpful during the development or testing of the webhook endpoint as you can emulate webhook execution with different payloads without making required changes in the Adobe Commerce application to trigger webhook execution.
+Run this command after setting the initial webhook payload in a `webhooks.xml` file, Then run the command again any time you make subsequent modifications to the payload until you can confirm that the payload works as expected.
 
 ### Usage
 

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -318,7 +318,7 @@ Instead pf manually adding a product to the cart from the storefront, you can ru
 ```bash
 bin/magento webhooks:dev:run observer.checkout_cart_product_add_before:before '{"data":{"product":{"sku":"simple-product","name":"Simple Product"}}}'
 
-The webhook endpoint will receive the next payload according to `fields` configured for the webhook:
+The webhook endpoint receives the following payload, according to `fields` configured for the webhook:
 
 ```json
 {"product":{"name":"Simple Product","sku":"simple-product"}}

--- a/src/pages/webhooks/commands.md
+++ b/src/pages/webhooks/commands.md
@@ -281,7 +281,7 @@ Module was generated in the app/code/Magento directory
 
 ## Emulate webhook execution
 
-The `webhooks:dev:run` command is used for development and testing purposes only. It emulates the execution of your registered webhook containing a custom payload with requiring changes to the Commerce application. 
+The `webhooks:dev:run` command is used for development and testing purposes only. It emulates the execution of your registered webhook containing a custom payload with requiring changes to the Commerce application.
 Run this command after setting the initial webhook payload in a `webhooks.xml` file, Then run the command again any time you make subsequent modifications to the payload until you can confirm that the payload works as expected.
 
 ### Usage


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about `webhooks:dev:run` command

https://jira.corp.adobe.com/browse/CEXT-2387

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
