### PR TITLE
Add discover block for webhooks

### DIFF
--- a/src/pages/admin-ui-sdk/release-notes.md
+++ b/src/pages/admin-ui-sdk/release-notes.md
@@ -8,6 +8,16 @@ keywords:
 
 # Adobe Commerce Admin UI SDK release notes
 
+## Version 1.1.2
+
+### Release date
+
+October 6, 2023
+
+### Enhancements
+
+Fixed security cross-site scripting (XSS) and password hash security vulnerabilities.
+
 ## Version 1.1.1
 
 ### Release date

--- a/src/pages/amazon-sales-channel/index.md
+++ b/src/pages/amazon-sales-channel/index.md
@@ -40,6 +40,6 @@ In general, the sample app looks and feels like the PHP extension. However, some
 
 ## Additional resources
 
-* Join the [#app-builder-community slack channel](https://github.com/AdobeDocs/commerce-extensibility/pull/49/magentocommeng.slack.com) in the Commerce Engineering Slack workspace to ask questions directly to teams and partners working with App Builder.
+* Join the [#app-builder-community slack channel](https://magentocommeng.slack.com/archives/C04KT43Q75K) in the Commerce Engineering Slack workspace to ask questions directly to teams and partners working with App Builder.
 
 * Review [Common Troubleshooting](https://developer.adobe.com/app-builder/docs/getting_started/common_troubleshooting/) in the App Builder _Getting Started_ guide for the latest debugging tips.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -35,6 +35,12 @@ Make Commerce transactional data available to App Builder using Adobe I/O. You c
 
 <DiscoverBlock slots="link, text"/>
 
+[Webhooks](webhooks/index.md)
+
+Configure webhooks to synchronously send data to an external system when an event triggers and update Adobe Commerce in real time.
+
+<DiscoverBlock slots="link, text"/>
+
 [Admin UI SDK](admin-ui-sdk/index.md)
 
 Extend the Commerce Admin to include the menus and pages necessary for merchants to configure and interact with your app.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a discover block for webhooks on the extensibility front page

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
