### PR TITLE
Instruction on how to install ece-tools from git

### DIFF
--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -27,7 +27,7 @@ The following steps apply to both Adobe Commerce on cloud infrastructure and on-
    bin/magento module:enable --all
    ```
 
-## On-premise installation
+## On-premises installation
 
 1. Run the following command to initialize the `AdobeCommerceWebhookPlugins` module. This module consists of generated plugins based on a list of subscribed webhooks.
 
@@ -65,9 +65,9 @@ Use the following steps to perform additional configuration for Adobe Commerce o
 
 1. Run the `composer info magento/ece-tools` command to determine your version of ece-tools. If the version is less than `2002.1.16`, [update to the most recent version](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/dev-tools/ece-tools/update-package.html).
 
-If the ece-tools version `2002.1.16` is not released yet, use the develop branch from the git:
+   If the ece-tools version `2002.1.16` is not available yet, install the `develop` branch from git.
 
-Add to the repositories section of your `composer.json`
+   Add the following to the `repositories` section of your `composer.json` file:
 
    ```json
       "ece-tools": {
@@ -76,13 +76,13 @@ Add to the repositories section of your `composer.json`
       },
    ```
 
-Add to the `require` section of your `composer.json`
+   Add the following to the `require` section of your `composer.json`:
 
    ```json
       "magento/ece-tools": "dev-develop as 2002.1.16",
    ```
 
-Run the `composer update`.
+   Run the `composer update` command.
 
 1. Enable webhooks in the `.magento.env.yaml` file:
 

--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -68,16 +68,20 @@ Use the following steps to perform additional configuration for Adobe Commerce o
 If the ece-tools version `2002.1.16` is not released yet, use the develop branch from the git:
 
 Add to the repositories section of your `composer.json`
+
 ```json
         "ece-tools": {
             "type": "git",
             "url": "git@github.com:magento/ece-tools.git"
         },
 ```
+
 Add to the `require` section of your `composer.json`
+
 ```json
     "magento/ece-tools": "dev-develop as 2002.1.16",
 ```
+
 Run the `composer update`.
 
 1. Enable webhooks in the `.magento.env.yaml` file:

--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -69,18 +69,18 @@ If the ece-tools version `2002.1.16` is not released yet, use the develop branch
 
 Add to the repositories section of your `composer.json`
 
-```json
-        "ece-tools": {
-            "type": "git",
-            "url": "git@github.com:magento/ece-tools.git"
-        },
-```
+   ```json
+      "ece-tools": {
+         "type": "git",
+         "url": "git@github.com:magento/ece-tools.git"
+      },
+   ```
 
 Add to the `require` section of your `composer.json`
 
-```json
-    "magento/ece-tools": "dev-develop as 2002.1.16",
-```
+   ```json
+      "magento/ece-tools": "dev-develop as 2002.1.16",
+   ```
 
 Run the `composer update`.
 

--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -65,6 +65,21 @@ Use the following steps to perform additional configuration for Adobe Commerce o
 
 1. Run the `composer info magento/ece-tools` command to determine your version of ece-tools. If the version is less than `2002.1.16`, [update to the most recent version](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/dev-tools/ece-tools/update-package.html).
 
+If the ece-tools version `2002.1.16` is not released yet, use the develop branch from the git:
+
+Add to the repositories section of your `composer.json`
+```json
+        "ece-tools": {
+            "type": "git",
+            "url": "git@github.com:magento/ece-tools.git"
+        },
+```
+Add to the `require` section of your `composer.json`
+```json
+    "magento/ece-tools": "dev-develop as 2002.1.16",
+```
+Run the `composer update`.
+
 1. Enable webhooks in the `.magento.env.yaml` file:
 
    ```yaml


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information on how to install ece-tools from git until 2002.1.16 version is released.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/installation/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
