### PR TITLE
CEXT-2403: Caching webhook responses

### DIFF
--- a/src/pages/webhooks/testing.md
+++ b/src/pages/webhooks/testing.md
@@ -44,3 +44,8 @@ If an error occurs, or if an exception is thrown, a message similar to the follo
 Failed to process webhook "observer.checkout_cart_product_add_before". Or webhook endpoint returned exception operation. Error: Webhook Response: The product is out of stock
 Check logs for more information.
 ```
+
+Responses for a webhook endpoint may be cached if the `ttl` attribute for a hook is set. To clean the webhook response cache while testing your webhooks locally, run the following command:
+```bash
+bin/magento cache:clean webhooks_response
+```

--- a/src/pages/webhooks/testing.md
+++ b/src/pages/webhooks/testing.md
@@ -46,6 +46,7 @@ Check logs for more information.
 ```
 
 Responses for a webhook endpoint may be cached if the `ttl` attribute for a hook is set. To clean the webhook response cache while testing your webhooks locally, run the following command:
+
 ```bash
 bin/magento cache:clean webhooks_response
 ```

--- a/src/pages/webhooks/xml-schema.md
+++ b/src/pages/webhooks/xml-schema.md
@@ -74,6 +74,7 @@ The `hook` element defines the HTTP request to the remote server.
 | `softTimeout`| Int    | A soft timeout limit (milliseconds) for the request. Requests exceeding this timeout are logged for debugging purposes. | false       | Not applicable     |
 | `fallbackErrorMessage` | Int    | The error message to return when the hook fails. | false       | Not applicable     |
 | `remove` | Boolean   | Indicates whether to skip a removed hook during the batch execution. | false       | false   |
+| `ttl` | Int    | A cache ttl (in seconds) for requests with the same url, body, and headers.  | false       | 0       |
 | `headers` | Array  | A set of HTTP headers to send with the request. | false       | []      |
 | `fields` | Array  | A set of fields to include in the hook payload. If not set, the entire payload will be sent. | false       | []      |
 

--- a/src/pages/webhooks/xml-schema.md
+++ b/src/pages/webhooks/xml-schema.md
@@ -74,7 +74,7 @@ The `hook` element defines the HTTP request to the remote server.
 | `softTimeout`| Int    | A soft timeout limit (milliseconds) for the request. Requests exceeding this timeout are logged for debugging purposes. | false       | Not applicable     |
 | `fallbackErrorMessage` | Int    | The error message to return when the hook fails. | false       | Not applicable     |
 | `remove` | Boolean   | Indicates whether to skip a removed hook during the batch execution. | false       | false   |
-| `ttl` | Int    | A cache ttl (in seconds) for requests with the same url, body, and headers.  | false       | 0       |
+| `ttl` | Int    | The cache time-to-live (in seconds) for requests with the same URL, body, and headers. If this attribute is not specified, or if the value set to `0`, the response is not cached. | false       | 0       |
 | `headers` | Array  | A set of HTTP headers to send with the request. | false       | []      |
 | `fields` | Array  | A set of fields to include in the hook payload. If not set, the entire payload will be sent. | false       | []      |
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about webhook response caching

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
