### PR TITLE
Fix wrong module names

### DIFF
--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -38,7 +38,7 @@ The following steps apply to both Adobe Commerce on cloud infrastructure and on-
 1. Enable the generated modules:
 
    ```bash
-   bin/magento module:enable AdobeCommerceWebhookPlugins
+   bin/magento module:enable Magento_AdobeCommerceWebhooks Magento_AdobeCommerceWebhooksGenerator
    ```
 
 1. Upgrade your instance:

--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -38,7 +38,7 @@ The following steps apply to both Adobe Commerce on cloud infrastructure and on-
 1. Enable the generated modules:
 
    ```bash
-   bin/magento module:enable Magento_AdobeCommerceWebhooks Magento_AdobeCommerceWebhooksGenerator
+   bin/magento module:enable Magento_AdobeCommerceWebhookPlugins Magento_AdobeCommerceWebhooksGenerator
    ```
 
 1. Upgrade your instance:

--- a/src/pages/webhooks/installation.md
+++ b/src/pages/webhooks/installation.md
@@ -38,7 +38,7 @@ The following steps apply to both Adobe Commerce on cloud infrastructure and on-
 1. Enable the generated modules:
 
    ```bash
-   bin/magento module:enable Magento_AdobeCommerceWebhookPlugins Magento_AdobeCommerceWebhooksGenerator
+   bin/magento module:enable Magento_AdobeCommerceWebhookPlugins
    ```
 
 1. Upgrade your instance:


### PR DESCRIPTION
## Purpose of this pull request

Module name in example does not exist. Fixed it.

## Affected pages


- https://developer.adobe.com/commerce/extensibility/webhooks/installation/