### PR TITLE
CEXT-2455: fromExternalFormat method in converter classes

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -138,7 +138,7 @@ The following example configures the webhook described above.
 
 You can implement a converter class to convert a field to a different data type. For example, Commerce stores order IDs as numeric values. If the hook endpoint expects order IDs to be text values, you must convert the numeric value to a string representation before sending the payload.
 
-All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`.
+All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`. The `toExternalFormat` method of a converter class is used to convert a field value before sending a request to the hook endpoint. 
 
 ```xml
 <fields>
@@ -146,6 +146,10 @@ All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter
     <field name='order.status' source='data.order.status' converter="Path/To/The/Converter/Class" />
 </fields>
 ```
+
+A converter class can also convert the value in a hook endpoint response object with an operation status of  `replace`. A value in a `replace` response object will only be converted if the path in the object corresponds to the source of a field with a configured converter class.
+
+For example, given the above hook field configuration, conversion will only occur if a `replace` response object specifies a path of `data/order/status`. In this case, the `fromExternalFormat` method of the configured converter class will be called to convert the value in the response object.
 
 ### Context fields
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -138,7 +138,7 @@ The following example configures the webhook described above.
 
 You can implement a converter class to convert a field to a different data type. For example, Commerce stores order IDs as numeric values. If the hook endpoint expects order IDs to be text values, you must convert the numeric value to a string representation before sending the payload.
 
-All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`. The `toExternalFormat` method of a converter class is used to convert a field value before sending a request to the hook endpoint.
+All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`. The `toExternalFormat` method of a converter class converts a field value before sending a request to the hook endpoint.
 
 ```xml
 <fields>
@@ -147,9 +147,9 @@ All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter
 </fields>
 ```
 
-A converter class can also convert the value in a hook endpoint response object with an operation status of  `replace`. A value in a `replace` response object will only be converted if the path in the object corresponds to the source of a field with a configured converter class.
+A converter class can also convert the value in a hook endpoint response object that has an operation status of  `replace`. A value in a `replace` response object will be converted only if the path in the object corresponds to the source of a field with a configured converter class.
 
-For example, given the above hook field configuration, conversion will only occur if a `replace` response object specifies a path of `data/order/status`. In this case, the `fromExternalFormat` method of the configured converter class will be called to convert the value in the response object.
+For example, given the above hook field configuration, conversion occurs only if a `replace` response object specifies a path of `data/order/status`. In this case, the `fromExternalFormat` method of the configured converter class will be called to convert the value in the response object.
 
 ### Context fields
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -138,7 +138,7 @@ The following example configures the webhook described above.
 
 You can implement a converter class to convert a field to a different data type. For example, Commerce stores order IDs as numeric values. If the hook endpoint expects order IDs to be text values, you must convert the numeric value to a string representation before sending the payload.
 
-All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`. The `toExternalFormat` method of a converter class is used to convert a field value before sending a request to the hook endpoint. 
+All converter classes must implement `Magento\AdobeCommerceWebhooks\Model\Filter\Converter\FieldConverterInterface`. The `toExternalFormat` method of a converter class is used to convert a field value before sending a request to the hook endpoint.
 
 ```xml
 <fields>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about converting values in hook endpoint responses containing replace operations (replace operation documentation to come in https://jira.corp.adobe.com/browse/CEXT-2484)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
