### PR TITLE
CEXT-2534: Documenting array-type field filtering

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -134,6 +134,93 @@ The following example configures the webhook described above.
 </hook>
 ```
 
+If the default payload of a webhook contains an array of objects, use the following construction to select fields from that array:
+
+```text
+<object_name>[].<field_name>
+```
+
+For example, the payload of the `plugin.magento.quote.api.shipment_estimation.estimate_by_extended_address` event contains a top-level `results[]` array. The array contains details about two individual shipping estimates.
+
+```json
+{
+    "subject": [],
+    "result": [
+        {
+            "carrier_code": "tablerate",
+            "method_code": "bestway",
+            "carrier_title": "Best Way",
+            "method_title": "Table Rate",
+            "amount": 15,
+            "base_amount": 15,
+            "available": true,
+            "error_message": "",
+            "price_excl_tax": 15,
+            "price_incl_tax": 15
+        },
+        {
+            "carrier_code": "flatrate",
+            "method_code": "flatrate",
+            "carrier_title": "Flat Rate",
+            "method_title": "Fixed",
+            "amount": 20,
+            "base_amount": 20,
+            "available": true,
+            "error_message": "",
+            "price_excl_tax": 20,
+            "price_incl_tax": 20
+        }
+    ],
+    "cartId": "21",
+    "address": {
+        "street": "123 Test Road",
+        "city": "Test City",
+        "region_id": 12,
+        "region": "California",
+        "country_id": "US",
+        "postcode": "90000",
+        "firstname": "Test",
+        "lastname": "Test",
+        "company": "",
+        "telephone": "1800000000",
+        "save_in_address_book": 1,
+        "region_code": "CA",
+        "extension_attributes": []
+    }
+}
+```
+
+To transmit the `postcode` property of the `address` object and the `carrier_code`, `method_code`, and `base_amount` for each shipping estimate, the webhook's fields can be configured as follows:
+
+```xml
+<fields>
+    <field name='postcode' source='address.postcode' />
+    <field name='result[].carrier_code' />
+    <field name='result[].method_code' />
+    <field name='result[].base_amount' />
+</fields>
+```
+
+The following object would then be sent to the remote application:
+
+```json
+{
+    "postcode": "90000",
+    "result": [
+        {
+            "carrier_code": "tablerate",
+            "method_code": "bestway",
+            "base_amount": 15
+        },
+        {
+            "carrier_code": "flatrate",
+            "method_code": "flatrate",
+            "base_amount": 20
+        }
+    ]
+}
+```
+
 ### Field converters
 
 You can implement a converter class to convert a field to a different data type. For example, Commerce stores order IDs as numeric values. If the hook endpoint expects order IDs to be text values, you must convert the numeric value to a string representation before sending the payload.

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -190,7 +190,7 @@ For example, the payload of the `plugin.magento.quote.api.shipment_estimation.es
 }
 ```
 
-To transmit the `postcode` property of the `address` object and the `carrier_code`, `method_code`, and `base_amount` for each shipping estimate, the webhook's fields can be configured as follows:
+To transmit the `postcode` property of the `address` object and the `carrier_code`, `method_code`, and `base_amount` for each shipping estimate, configure the webhook's fields as follows:
 
 ```xml
 <fields>
@@ -201,7 +201,7 @@ To transmit the `postcode` property of the `address` object and the `carrier_cod
 </fields>
 ```
 
-The following object would then be sent to the remote application:
+Commerce sends the following object to the remote application:
 
 ```json
 {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about configuring webhooks with array-type fields
https://jira.corp.adobe.com/browse/CEXT-2534

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/hooks/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
