### PR TITLE
Add Webhooks keyword

### DIFF
--- a/.github/linters/metadata.schema.yml
+++ b/.github/linters/metadata.schema.yml
@@ -26,6 +26,7 @@ properties:
         - Security
         - Tools
         - Upgrade
+        - Webhooks
 
 required:
   - title


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the Webhooks keyword  so that it can be used in the frontmatter.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
