### PR TITLE
Remove discussion of installing ASC

### DIFF
--- a/src/pages/amazon-sales-channel/index.md
+++ b/src/pages/amazon-sales-channel/index.md
@@ -22,7 +22,7 @@ Amazon Sales Channel on App Builder is based on an existing PHP extension (Amazo
 
 <InlineAlert variant="warning" slots="text" />
 
-This app is not intended or supported for production use. While the provided capabilities are robust, they are only to be used as a reference to build your own applications. Merchants looking to connect and synchronize their Amazon store with Commerce should use the existing Amazon Sales Channel PHP extension, which can be acquired through Commerce Marketplace, or implement another integration.
+This app is not intended or supported for production use. While the provided capabilities are robust, they are only to be used as a reference to build your own applications. Merchants looking to connect and synchronize their Amazon store with Commerce should implement another integration.
 
 To install this app, clone the [aio-amazon-sales-channel](https://github.com/adobe/amazon-sales-channel-app-builder) repo and follow the procedures described in [Prequisites](prerequisites.md) and [Install the Amazon Sales Channel app](installation.md).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the ASC reference app intro to remove a reference to installing the extension. The extension has been removed from Marketplace.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
