### PR TITLE
Add note about generating fixtures

### DIFF
--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -179,6 +179,10 @@ You can also subscribe to a plugin event if it was registered in the `app/etc/co
 
 You can also create and subscribe to a conditional event. Conditional events allow you to determine the conditions that the Commerce events client module uses to emit native or custom events to your application. See [Create conditional events](./conditional-events.md) for detailed information and examples.
 
+<InlineAlert variant="info" slots="text"/>
+
+If you are implementing eventing in a performance testing environment, run the `bin/magento setup:perf:generate-fixtures` command before subscribing any events. Subscribing events before generating fixtures can cause errors.
+
 ### Usage
 
 `bin/magento events:subscribe <event_code> --force --fields=<name1> --fields=<name2> --parent <event_code> --rules=<field-name>|<operator>|<value> --rules=<field-name2>|<operator>|<value2>`


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note about generating fixtures before subscribing events in a performance testing environment. This is an obscure corner case.

Related: https://git.corp.adobe.com/AdobeDocs/commerce-operations.en/pull/731

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
