### PR TITLE
Add basic navigation

### DIFF
--- a/src/data/navigation/header.js
+++ b/src/data/navigation/header.js
@@ -20,6 +20,10 @@ module.exports = [
       path: "/admin-ui-sdk/",
     },
     {
+      title: "Starter Kit",
+      path: "/starter-kit/"
+    },
+    {
       title: "Reference App",
       path: "/amazon-sales-channel/"
     }

--- a/src/data/navigation/sections/index.js
+++ b/src/data/navigation/sections/index.js
@@ -2,6 +2,7 @@ const appdev = require("./app-development");
 const eventing = require("./events");
 const wh = require("./webhooks");
 const adminuisdk = require("./admin-ui-sdk");
+const starter = require("./starter-kit");
 const amazon = require("./amazon-sales-channel");
 
-module.exports = [...appdev, ...eventing, ...wh, ...adminuisdk, ...amazon];
+module.exports = [...appdev, ...eventing, ...wh, ...adminuisdk, ...starter, ...amazon];

--- a/src/data/navigation/sections/starter-kit.js
+++ b/src/data/navigation/sections/starter-kit.js
@@ -1,0 +1,6 @@
+module.exports = [
+    {
+        title: "Overview",
+        path: "/starter-kit/index.md"   
+    }
+];

--- a/src/pages/starter-kit/index.md
+++ b/src/pages/starter-kit/index.md
@@ -1,0 +1,9 @@
+---
+title: Overview
+description: TBD.
+keywords:
+  - App Builder
+  - Extensibility
+---
+
+# Overview


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds basic navigation for the Starter Kit docs. No content whatsoever.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
