### PR TITLE
Correct order view parameters

### DIFF
--- a/src/pages/admin-ui-sdk/extension-points/order/view-button.md
+++ b/src/pages/admin-ui-sdk/extension-points/order/view-button.md
@@ -50,4 +50,4 @@ order: {
 | `path` | string | Yes | The relative path to the button page in the App. The order ID will be sent as part of the query. |
 | `level` | integer | No |  The position in which a set of buttons are placed in the toolbar. The possible values are `-1` (left), `0` (center), and `1` (right). |
 | `sortOrder` | integer | No | The order in which the button is placed inside the level. |
-| `class` | string | Yes  | The class of the button type. Possible values are `save`, `edit`, `reset`, and `custom`.
+| `class` | string | Yes  | The class of the button. Possible values are `save`, `edit`, `reset`, and `custom`. |

--- a/src/pages/admin-ui-sdk/extension-points/order/view-button.md
+++ b/src/pages/admin-ui-sdk/extension-points/order/view-button.md
@@ -45,8 +45,9 @@ order: {
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `buttonId` | string | Yes | A unique ID to identify the button. We recommend using the format `<extensionId>::<buttonName>`. |
-| `label` | string | No | The label of the button. |
+| `label` | string | Yes | The label of the button. |
 | `confirm.message` | string | No | Confirmation message to display. |
 | `path` | string | Yes | The relative path to the button page in the App. The order ID will be sent as part of the query. |
-| `level` | integer | Yes |  The position in which a set of buttons are placed in the toolbar. The possible values are `-1` (left), `0` (center), and `1` (right). |
+| `level` | integer | No |  The position in which a set of buttons are placed in the toolbar. The possible values are `-1` (left), `0` (center), and `1` (right). |
 | `sortOrder` | integer | No | The order in which the button is placed inside the level. |
+| `class` | string | Yes  | The class of the button type. Possible values are `save`, `edit`, `reset`, and `custom`.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) makes corrections to the order view button parameters.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
