### PR TITLE
Remove class from order button

### DIFF
--- a/src/pages/admin-ui-sdk/extension-points/order/view-button.md
+++ b/src/pages/admin-ui-sdk/extension-points/order/view-button.md
@@ -23,7 +23,6 @@ order: {
                 message: 'Are you sure your want to delete the order?'
                 },
                 path: '#/delete-order',
-                class: 'custom',
                 level: 0,
                 sortOrder: 80
             },
@@ -31,7 +30,6 @@ order: {
                 buttonId: `${extensionId}::create-return`,
                 label: 'Create a return',
                 path: '#/create-return',
-                class: 'custom',
                 level: 0,
                 sortOrder: 80
             }
@@ -50,4 +48,3 @@ order: {
 | `path` | string | Yes | The relative path to the button page in the App. The order ID will be sent as part of the query. |
 | `level` | integer | No |  The position in which a set of buttons are placed in the toolbar. The possible values are `-1` (left), `0` (center), and `1` (right). |
 | `sortOrder` | integer | No | The order in which the button is placed inside the level. |
-| `class` | string | Yes  | The class of the button. Possible values are `save`, `edit`, `reset`, and `custom`. |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the class parameter from the order view button extension point.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
