### PR TITLE
CEXT-2783: Documentation on how to resolve stuck deployment on the Cloud

### DIFF
--- a/src/pages/events/configure-commerce.md
+++ b/src/pages/events/configure-commerce.md
@@ -145,6 +145,8 @@ stage:
       consumers: []
 ```
 
+**Warning**: Due to the specific of the Cloud environment the deployment process may stuck if you have the running consumer in the background. See how to [resolve stuck deployment](./troubleshooting.md#stuck-deployment-on-cloud-environment-after-configuring-priority-events).
+
 See [Global variables](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure/env/stage/variables-global.html) for more information about the `ENABLE_EVENTING` variable.
 
 Cloud infrastructure and on-premises instances require different cron management procedures as described here:

--- a/src/pages/events/configure-commerce.md
+++ b/src/pages/events/configure-commerce.md
@@ -145,7 +145,9 @@ stage:
       consumers: []
 ```
 
-**Warning**: Due to the specific of the Cloud environment the deployment process may stuck if you have the running consumer in the background. See how to [resolve stuck deployment](./troubleshooting.md#stuck-deployment-on-cloud-environment-after-configuring-priority-events).
+<InlineAlert variant="warning" slots="text" />
+
+The deployment process might become stuck if the consumer runs in the background. The [Troubleshooting](./troubleshooting.md#stuck-deployment-after-configuring-priority-events) topic describes how to resolve this condition.
 
 See [Global variables](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure/env/stage/variables-global.html) for more information about the `ENABLE_EVENTING` variable.
 

--- a/src/pages/events/troubleshooting.md
+++ b/src/pages/events/troubleshooting.md
@@ -112,3 +112,36 @@ bin/magento events:metadata:populate
 ```
 
 After refreshing the page with your App Builder project, you should be able to find the provider.
+
+## Stuck deployment on Cloud environment after configuring priority events
+
+Due to the specific of the deployment on Cloud environments, the deployment process can stuck in some cases when consumers are running in the background.
+To resolve the issue you need to `ssh` into your environment and manually kill the consumer process
+
+```bash
+magento-cloud ssh
+```
+
+```bash
+ps aux | grep consumer
+```
+
+It will return the list of running consumers
+
+```terminal
+web          980  2.4  0.0 232176 163012 ?       S    22:22   0:00 /usr/bin/php8.1-zts /app/bin/magento queue:consumers:start commerce.eventing.event.publish
+```
+
+And to run the command to kill the consumer
+
+```bash
+kill -9 <PROCESS_ID>
+```
+
+or to run the command provided by `ece-tools`
+
+```bash 
+vendor/bin/ece-tools cron:kill
+```
+
+After a short period, the deployment should continue running.

--- a/src/pages/events/troubleshooting.md
+++ b/src/pages/events/troubleshooting.md
@@ -140,7 +140,7 @@ kill -9 <PROCESS_ID>
 
 or to run the command provided by `ece-tools`
 
-```bash 
+```bash
 vendor/bin/ece-tools cron:kill
 ```
 

--- a/src/pages/events/troubleshooting.md
+++ b/src/pages/events/troubleshooting.md
@@ -113,35 +113,36 @@ bin/magento events:metadata:populate
 
 After refreshing the page with your App Builder project, you should be able to find the provider.
 
-## Stuck deployment on Cloud environment after configuring priority events
+## Stuck deployment after configuring priority events
 
-Due to the specific of the deployment on Cloud environments, the deployment process can stuck in some cases when consumers are running in the background.
-To resolve the issue you need to `ssh` into your environment and manually kill the consumer process
+The deployment process can get stuck in some cases in the Cloud environment when consumers are running in the background. To resolve the issue, you must `ssh` into your environment and manually kill the consumer process.
 
-```bash
-magento-cloud ssh
-```
+1. Use SSH to log in to the remote environment.
 
-```bash
-ps aux | grep consumer
-```
+   ```bash
+   magento-cloud ssh
+   ```
 
-It will return the list of running consumers
+1. Find the consumer processes.
 
-```terminal
-web          980  2.4  0.0 232176 163012 ?       S    22:22   0:00 /usr/bin/php8.1-zts /app/bin/magento queue:consumers:start commerce.eventing.event.publish
-```
+   ```bash
+   ps aux | grep consumer
+   ```
 
-And to run the command to kill the consumer
+   The response lists the running consumers.
 
-```bash
-kill -9 <PROCESS_ID>
-```
+   ```terminal
+   web          980  2.4  0.0 232176 163012 ?       S    22:22   0:00 /usr/bin/php8.1-zts /app/bin/magento queue:consumers:start commerce.eventing.event.publish
+   ```
 
-or to run the command provided by `ece-tools`
+1. Use one of the following commands to kill the consumer:
 
-```bash
-vendor/bin/ece-tools cron:kill
-```
+   ```bash
+   kill -9 <PROCESS_ID>
+   ```
 
-After a short period, the deployment should continue running.
+   ```bash
+   vendor/bin/ece-tools cron:kill
+   ```
+
+By default, the consumer will restart within one minute, but this value may vary, based on your [cron configuration](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure/app/properties/crons-property.html) or whether you have set up a [worker](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure/app/properties/workers-property.html).


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add documentation on how to resolve stuck deployment on the Cloud due to running in the background eventing consumers.

https://jira.corp.adobe.com/browse/CEXT-2783

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/configure-commerce/
- https://developer.adobe.com/commerce/extensibility/events/troubleshooting/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
