### PR TITLE
CEXT-2784: Release commerce eventing and webhook modules

### DIFF
--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,20 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.5.0
+
+### Release date
+
+February 7, 2024
+
+### Enhancements
+
+* Added support of field converters. Now you can specify converter class that will be applied to fields in the event payload. <!--- CEXT-1699 -->
+
+* Added event tracking ID field for better tracking of the event delivery process.  <!--- CEXT-2759 -->
+
+* Increased test coverage of eventing modules <!--- CEXT-2640 -->
+
 ## Version 1.4.1
 
 ### Release date

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -20,11 +20,11 @@ February 7, 2024
 
 ### Enhancements
 
-* Added support of field converters. Now you can specify converter class that will be applied to fields in the event payload. <!--- CEXT-1699 -->
+*  Added support for [field converters](convert-field-values.md). You can now create a converter class that changes the data type or value of fields in an event payload. <!--- CEXT-1699 -->
 
-* Added event tracking ID field for better tracking of the event delivery process.  <!--- CEXT-2759 -->
+* Added an event tracking ID field for better tracking of the event delivery process.  <!--- CEXT-2759 -->
 
-* Increased test coverage of eventing modules <!--- CEXT-2640 -->
+* Increased test coverage of eventing modules. <!--- CEXT-2640 -->
 
 ## Version 1.4.1
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add information about the new release of commerce eventing

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
