### PR TITLE
Webhooks admin configuration warning addition

### DIFF
--- a/src/pages/webhooks/admin-configuration.md
+++ b/src/pages/webhooks/admin-configuration.md
@@ -25,7 +25,7 @@ Click **Add New Webhook** from the grid page to display the form for creating a 
 
 <InlineAlert variant="warning" slots="text" />
 
-On Cloud instances, due to the read-only file system, the `webhooks:generate:module` command cannot be run. If a plugin-type webhook is added through the Admin, the method name and type should be declared in a `webhooks.xml` file.
+On Cloud instances, due to the read-only file system, the `webhooks:generate:module` command cannot be run. If a plugin-type webhook is added through the Admin, the method name and type should be declared in a `webhooks.xml` file so that the required plugins are generated during the build phase of the deployment process.
 
 ## Edit an existing hook
 

--- a/src/pages/webhooks/admin-configuration.md
+++ b/src/pages/webhooks/admin-configuration.md
@@ -25,7 +25,7 @@ Click **Add New Webhook** from the grid page to display the form for creating a 
 
 <InlineAlert variant="warning" slots="text" />
 
-On Cloud instances, due to the read-only file system, the `webhooks:generate:module` command cannot be run. If a plugin-type webhook is added through the Admin, the method name and type should be declared in a `webhooks.xml` file so that the required plugins are generated during the build phase of the deployment process.
+On Cloud instances, due to the read-only file system, the `webhooks:generate:module` command cannot be run. If a plugin-type webhook is added through the Admin, the method name and type should be declared in a `webhooks.xml` file so that the required plugin is generated during the build phase of the deployment process.
 
 ## Edit an existing hook
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds to the warning on the webhooks admin configuration page about adding new plugin-type webhooks.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
