### PR TITLE
Reorder sections on front page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -40,18 +40,6 @@ Other benefits of out-of-process extensibility include:
 
 <p></p>
 
-## In-process development tools
-
-Adobe Commerce and Magento Open Source provide the following in-process extensible development tools:
-
-- [REST](https://developer.adobe.com/commerce/webapi/rest) - Use REST calls to interact with your Commerce instance on behalf of an administrator, customer, guest, or integration.
-
-- [GraphQL](https://developer.adobe.com/commerce/webapi/graphql/) - Use GraphQL requests to transfer information between the storefront and backend.
-
-- [PHP Extensions](https://developer.adobe.com/commerce/php/development/) - Develop or modify Adobe Commerce and Magento Open Source components.
-
-- [Marketplace Extensions](https://developer.adobe.com/commerce/marketplace/guides/sellers/extensions/) - Create and sell PHP extensions in the [Adobe Commerce Marketplace](https://commercemarketplace.adobe.com).
-
 ## Out-of-process development tools
 
 Adobe Commerce offers the following out-of-process development tools:
@@ -71,6 +59,18 @@ Additionally, [Marketplace Apps](./app-development/index.md) allow you to create
 <InlineAlert variant="info" slots="text"/>
 
 Some out-of-process development tools are only available with Adobe Commerce and are not available with Magento Open Source.
+
+## In-process development tools
+
+Adobe Commerce and Magento Open Source provide the following in-process extensible development tools:
+
+- [REST](https://developer.adobe.com/commerce/webapi/rest) - Use REST calls to interact with your Commerce instance on behalf of an administrator, customer, guest, or integration.
+
+- [GraphQL](https://developer.adobe.com/commerce/webapi/graphql/) - Use GraphQL requests to transfer information between the storefront and backend.
+
+- [PHP Extensions](https://developer.adobe.com/commerce/php/development/) - Develop or modify Adobe Commerce and Magento Open Source components.
+
+- [Marketplace Extensions](https://developer.adobe.com/commerce/marketplace/guides/sellers/extensions/) - Create and sell PHP extensions in the [Adobe Commerce Marketplace](https://commercemarketplace.adobe.com).
 
 ### Related information
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves the OOP section of the front page to be above the in-process page.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
