### PR TITLE
Add logging to learning path

### DIFF
--- a/src/pages/app-development/learning-path.md
+++ b/src/pages/app-development/learning-path.md
@@ -68,3 +68,5 @@ The following resources will help you get to know the extensibility options offe
 ## Troubleshooting
 
 - [Logging and troubleshooting in App Builder](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/best-practices/logging-troubleshooting/)
+- [Adobe I/O Events frequently asked questions](https://developer.adobe.com/events/docs/support/faq/)
+- [App Builder security overview](https://developer.adobe.com/app-builder/docs/guides/security/)

--- a/src/pages/app-development/learning-path.md
+++ b/src/pages/app-development/learning-path.md
@@ -22,7 +22,6 @@ The following resources will help you get to know the extensibility options offe
 - [Use Cases](https://www.youtube.com/watch?v=spm90jwC94A&t=1s) - a one-hour video on common App Builder use cases.
 - [Sample App](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/) - An internally developed sample app with best practices and references to an example GitHub repo.
 - [Demo](https://experienceleague.adobe.com/docs/commerce-learn/tutorials/adobe-developer-app-builder/app-builder-functional-demonstration.html) - A short video demonstrating a functional integration between Commerce and Amazon Marketplace.
-- [Logging and troubleshooting](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/best-practices/logging-troubleshooting/)
 
 ## How can I get set up?
 
@@ -65,3 +64,7 @@ The following resources will help you get to know the extensibility options offe
   - [Configuration](https://developer.adobe.com/commerce/extensibility/webhooks/hooks/) - Developer documentation on how to configure hooks for Adobe Commerce.
   - [Common use cases](https://developer.adobe.com/commerce/extensibility/webhooks/use-cases/) - Descriptions of common Adobe Commerce use cases for webhooks.
   - [Webhooks](https://developer.adobe.com/commerce/extensibility/webhooks/admin-configuration/) - Learn how to extend, override, and create hooks using the Adobe Commerce Admin.
+
+## Troubleshooting
+
+- [Logging and troubleshooting in App Builder](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/best-practices/logging-troubleshooting/)

--- a/src/pages/app-development/learning-path.md
+++ b/src/pages/app-development/learning-path.md
@@ -22,6 +22,7 @@ The following resources will help you get to know the extensibility options offe
 - [Use Cases](https://www.youtube.com/watch?v=spm90jwC94A&t=1s) - a one-hour video on common App Builder use cases.
 - [Sample App](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/) - An internally developed sample app with best practices and references to an example GitHub repo.
 - [Demo](https://experienceleague.adobe.com/docs/commerce-learn/tutorials/adobe-developer-app-builder/app-builder-functional-demonstration.html) - A short video demonstrating a functional integration between Commerce and Amazon Marketplace.
+- [Logging and troubleshooting](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/best-practices/logging-troubleshooting/)
 
 ## How can I get set up?
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a link for [logging and troubleshooting](https://developer.adobe.com/commerce/extensibility/amazon-sales-channel/best-practices/logging-troubleshooting/) to the [learning path](https://developer.adobe.com/commerce/extensibility/app-development/learning-path/).