### PR TITLE
CEXT-2869: Release commerce eventing and commerce eventing service

### DIFF
--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -205,7 +205,7 @@ If you are implementing eventing in a performance testing environment, run the `
 
 `--fields='{"<name>":"<field-name>", "converter":"<path\to\converterclass>"}'` Applies the converter class to the given field.
 
-`--destination`, `-d` The destination of this event. Specify this option for the events that should be delivered to the custom destination.
+`--destination`, `-d` A custom destination for the event. This argument is used for SaaS integrations.
 
 ### Example
 

--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -205,6 +205,8 @@ If you are implementing eventing in a performance testing environment, run the `
 
 `--fields='{"<name>":"<field-name>", "converter":"<path\to\converterclass>"}'` Applies the converter class to the given field.
 
+`--destination`, `-d` The destination of this event. Specify this option for the events that should be delivered to the custom destination.
+
 ### Example
 
 To subscribe to a native event:

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -18,13 +18,13 @@ See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io
 
 March 4, 2024
 
-* Changed the format of the event tracking ID to uuid4 <!--- CEXT-2853 -->
-
-* Added a destination option to the event:subscribe CLI command <!--- CEXT-2895 -->
- 
-* Fixed an issue when the event metadata was created for a configured event provider for events with a custom destination <!--- CEXT-2857 -->
-
 ### Enhancements
+
+* Changed the format of the event tracking ID to uuid4. <!--- CEXT-2853 -->
+
+* Added the `--destination` option to the `event:subscribe` command. <!--- CEXT-2895 -->
+ 
+* Fixed an issue that occurred when the event metadata was created for a configured event provider for events with a custom destination. <!--- CEXT-2857 -->
 
 ## Version 1.5.0
 

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -23,7 +23,7 @@ March 4, 2024
 * Changed the format of the event tracking ID to uuid4. <!--- CEXT-2853 -->
 
 * Added the `--destination` option to the `event:subscribe` command. <!--- CEXT-2895 -->
- 
+
 * Fixed an issue that occurred when the event metadata was created for a configured event provider for events with a custom destination. <!--- CEXT-2857 -->
 
 ## Version 1.5.0

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,20 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.5.1
+
+### Release date
+
+March 4, 2024
+
+* Changed the format of the event tracking ID to uuid4 <!--- CEXT-2853 -->
+
+* Added a destination option to the event:subscribe CLI command <!--- CEXT-2895 -->
+ 
+* Fixed an issue when the event metadata was created for a configured event provider for events with a custom destination <!--- CEXT-2857 -->
+
+### Enhancements
+
 ## Version 1.5.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) will add release notes for the 1.5.1 release

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [Release notes](https://developer.adobe.com/commerce/extensibility/events/release-notes/)

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
