### PR TITLE
Update Adobe IO State Library details

### DIFF
--- a/src/pages/amazon-sales-channel/best-practices/database-storage.md
+++ b/src/pages/amazon-sales-channel/best-practices/database-storage.md
@@ -32,11 +32,11 @@ The throttling controls of Amazon's Selling Partner APIs significantly impact ap
 
 The `lib-state` library has clear limitations both in practice and from the public documentation. A common misconception is that this library is a replacement for a traditional RDBMS/noSQL database. Instead, it has technical capabilities that are similar to Redis or other caching services. The library [README](https://github.com/adobe/aio-lib-state) lists these limitations:
 
-* Maximum state value size: 2MB
+* The namespace must be in the valid AppBuilder format: `amsorg-project(-workspace)?`
+* Maximum state value size: 1MB
 * Maximum state key size: 1024 bytes
-* Maximum total state size: 10 GB
-* Token expiry (need to re-init after expiry): 1 hour
-* Non-supported characters for state keys are: '/', '\', '?', '#'
+* Alphanumeric characters are supported as well as `-` (dash), `_` (underbar), and `.` (period)
+* The default TTL value is one day. The maximum is 365 days.
 
 These additional limitations should also be considered:
 

--- a/src/pages/amazon-sales-channel/best-practices/database-storage.md
+++ b/src/pages/amazon-sales-channel/best-practices/database-storage.md
@@ -32,7 +32,7 @@ The throttling controls of Amazon's Selling Partner APIs significantly impact ap
 
 The `lib-state` library has clear limitations both in practice and from the public documentation. A common misconception is that this library is a replacement for a traditional RDBMS/noSQL database. Instead, it has technical capabilities that are similar to Redis or other caching services. The library [README](https://github.com/adobe/aio-lib-state) lists these limitations:
 
-* The namespace must be in the valid AppBuilder format: `amsorg-project(-workspace)?`
+* The namespace must be in the valid AppBuilder format: `amsorg-project(-workspace)`
 * Maximum state value size: 1MB
 * Maximum state key size: 1024 bytes
 * Alphanumeric characters are supported as well as `-` (dash), `_` (underbar), and `.` (period)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates limitations about the Adobe I/O State Library. The [README](https://github.com/adobe/aio-lib-state) for this library was updated last week.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
