### PR TITLE
Fit the request method type

### DIFF
--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -12,7 +12,7 @@ Adobe Commerce provides several REST endpoints that interact with the eventing p
 
 ## Subscribe to events
 
-The `PUT /rest/<store_view_code>/V1/eventing/eventSubscribe` endpoint subscribes the event defined in the payload. The request body has the following format:
+The `POST /rest/<store_view_code>/V1/eventing/eventSubscribe` endpoint subscribes the event defined in the payload. The request body has the following format:
 
 ```json
 {
@@ -59,7 +59,7 @@ Review the [`events:subscribe` command](./commands.md#subscribe-to-an-event) to 
 The following cURL command subscribes to the `observer.catalog_category_save_after` event. The events contain the `name` and `entity_id` field. The priority setting expedites the transmission of this event.
 
 ```bash
-curl -i -X PUT \
+curl -i -X POST \
    -H "Content-Type:application/json" \
    -H "Authorization:Bearer <AUTH_TOKEN>" \
    -d \


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the error with wrong request type for the API endpoint

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/api/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
