### PR TITLE
CEXT-3055: Release commerce webhooks 1.3.0

### DIFF
--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -17,9 +17,9 @@ April 22, 2024
 
 ### Enhancements
 
-* Added additional validation while saving webhooks in Admin UI. <!--CEXT-3053 -->
+* Added additional validation while saving webhooks in the Admin. <!--CEXT-3053 -->
 
-* Added the list of disallowed plugins. <!--CEXT-3051-->
+* Added a list of disallowed plugins. <!--CEXT-3051-->
 
 ## Version 1.2.1
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,18 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.3.0
+
+### Release date
+
+April 22, 2024
+
+### Enhancements
+
+* Added additional validation while saving webhooks in Admin UI. <!--CEXT-3053 -->
+
+* Added the list of disallowed plugins. <!--CEXT-3051-->
+
 ## Version 1.2.1
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about 1.3.0 webhooks release

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
