### PR TITLE
Add missing beta notices

### DIFF
--- a/src/_includes/starter-kit-beta.md
+++ b/src/_includes/starter-kit-beta.md
@@ -1,3 +1,3 @@
 <InlineAlert variant="warning" slots="text" />
 
-**Adobe Commerce Starter Kit is for Beta users only and is not yet accessible to all customers.**
+**Adobe Commerce Starter Kit is for Beta users only and is not yet accessible to all customers.** [Sign up](https://forms.office.com/r/YbYArqE3DT) to be notified about updates and beta opportunities.

--- a/src/data/navigation/sections/starter-kit.js
+++ b/src/data/navigation/sections/starter-kit.js
@@ -34,7 +34,7 @@ module.exports = [
         path: "/starter-kit/send-data.md"
     },
     {
-        title: "Enrich Shopping experiences",
+        title: "Enrich the shopping experience",
         path: "/starter-kit/receive-data.md"
     },
     {

--- a/src/data/navigation/sections/starter-kit.js
+++ b/src/data/navigation/sections/starter-kit.js
@@ -34,7 +34,7 @@ module.exports = [
         path: "/starter-kit/send-data.md"
     },
     {
-        title: "Enrich Shopping experience",
+        title: "Enrich Shopping experiences",
         path: "/starter-kit/receive-data.md"
     },
     {

--- a/src/pages/starter-kit/contact-us.md
+++ b/src/pages/starter-kit/contact-us.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # Contact us
 
 ## Report an issue

--- a/src/pages/starter-kit/create-data-flow.md
+++ b/src/pages/starter-kit/create-data-flow.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # Create a new data flow
 
 Coming soon!

--- a/src/pages/starter-kit/customers.md
+++ b/src/pages/starter-kit/customers.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # `customer` data flow
 
 This page describes the path that data takes as it travels between Adobe Commerce and your backoffice system when using the Adobe Commerce Extensibility Starter Kit.

--- a/src/pages/starter-kit/index.md
+++ b/src/pages/starter-kit/index.md
@@ -8,6 +8,10 @@ keywords:
 
 # Adobe Commerce App Developer's Guide Overview
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 This will be the front page.
 
 ![front page](../_images/starterkit/temp-screenshot.png)

--- a/src/pages/starter-kit/launch.md
+++ b/src/pages/starter-kit/launch.md
@@ -10,4 +10,8 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # Prepare for launch

--- a/src/pages/starter-kit/orders.md
+++ b/src/pages/starter-kit/orders.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # `order` data flow
 
 This page describes the path that data takes as it travels between Adobe Commerce and your backoffice system when using the Adobe Commerce Extensibility Starter Kit.

--- a/src/pages/starter-kit/products.md
+++ b/src/pages/starter-kit/products.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # `product` data flow
 
 This page describes the path that data takes as it travels between Adobe Commerce and your backoffice system when using the Adobe Commerce Extensibility Starter Kit.

--- a/src/pages/starter-kit/receive-data.md
+++ b/src/pages/starter-kit/receive-data.md
@@ -1,5 +1,5 @@
 ---
-title: Enrich Shopping experiences
+title: Enrich the shopping experience
 description: Learn about how to receive data from the external backoffice application.
 keywords:
  - Extensibility
@@ -27,7 +27,7 @@ import integration from '/src/_includes/integration.md'
 
 <BetaNote />
 
-# Enrich Shopping experience
+# Enrich the shopping experience
 
 This runtime action is responsible for notifying Adobe Commerce when an `<object>` is created, updated, or deleted in the external backoffice application.
 

--- a/src/pages/starter-kit/receive-data.md
+++ b/src/pages/starter-kit/receive-data.md
@@ -1,5 +1,5 @@
 ---
-title: Enrich Shopping experience
+title: Enrich Shopping experiences
 description: Learn about how to receive data from the external backoffice application.
 keywords:
  - Extensibility

--- a/src/pages/starter-kit/shipments.md
+++ b/src/pages/starter-kit/shipments.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # `shipment` data flow
 
 This page describes the path that data takes as it travels between Adobe Commerce and your backoffice system when using the Adobe Commerce Extensibility Starter Kit.

--- a/src/pages/starter-kit/stock.md
+++ b/src/pages/starter-kit/stock.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # `stock` data flow
 
 This page describes the path that data takes as it travels between Adobe Commerce and your backoffice system when using the Adobe Commerce Extensibility Starter Kit.

--- a/src/pages/starter-kit/structure.md
+++ b/src/pages/starter-kit/structure.md
@@ -10,6 +10,10 @@ keywords:
  - Tools
 ---
 
+import BetaNote from '/src/_includes/starter-kit-beta.md'
+
+<BetaNote />
+
 # Starter Kit structure
 
 The Adobe Commerce Extensibility Starter Kit provides boilerplate code to synchronize the following entities across systems:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds beta notices to all the files that don't have one. It also adds contact info to the notice

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
