### PR TITLE
CEXT-3067: Release commerce webhooks 1.3.1

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -223,7 +223,7 @@ Commerce sends the following object to the remote application:
 
 <InlineAlert variant="warning" slots="text" />
 
-Some sensitive data like passwords can be sanitized in the webhook payload due to security concerns.
+Some sensitive data, such as passwords, can be sanitized in the webhook payload due to security concerns.
 
 ### Field converters
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -221,6 +221,10 @@ Commerce sends the following object to the remote application:
 }
 ```
 
+<InlineAlert variant="warning" slots="text" />
+
+Some sensitive data like passwords can be sanitized in the webhook payload due to security concerns.
+
 ### Field converters
 
 You can implement a converter class to convert a field to a different data type. For example, Commerce stores order IDs as numeric values. If the hook endpoint expects order IDs to be text values, you must convert the numeric value to a string representation before sending the payload.

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,18 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.3.1
+
+### Release date
+
+April 22, 2024
+
+### Enhancements
+
+* Added sanitization of sensitive data in webhooks payload. <!--CEXT-3063 -->
+
+* Making disallowed webhook expression case-insensitive. <!--CEXT-3076 -->
+
 ## Version 1.3.0
 
 ### Release date

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -13,13 +13,13 @@ These release notes describe the latest version of Adobe Commerce Webhooks.
 
 ### Release date
 
-April 22, 2024
+April 25, 2024
 
 ### Enhancements
 
-* Added sanitization of sensitive data in webhooks payload. <!--CEXT-3063 -->
+* Added the ability to sanitize sensitive data in the payload of webhooks. <!--CEXT-3063 -->
 
-* Making disallowed webhook expression case-insensitive. <!--CEXT-3076 -->
+* Made disallowed webhook expressions case-insensitive. <!--CEXT-3076 -->
 
 ## Version 1.3.0
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about 1.3.1 webhooks release
https://jira.corp.adobe.com/browse/CEXT-3067

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/hooks/
- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
