### PR TITLE
Add reference to info action

### DIFF
--- a/src/pages/starter-kit/create-integration.md
+++ b/src/pages/starter-kit/create-integration.md
@@ -158,53 +158,9 @@ In the Beta phase of the Starter Kit project, an Adobe Commerce representative w
    aio app use --merge
    ```
 
-1. The `app.config.yaml` in the repo's root directory defines which packages to deploy. The Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any packages that you do not need to deploy. In the following example, the `ingestion` package has been disabled:
+1. The `app.config.yaml` in the repo's root directory defines which packages to deploy. The Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any packages that you do not need to deploy.
 
-   ```yaml
-   application:
-   runtimeManifest:
-    packages:
-    #  ingestion:
-    #    license: Apache-2.0
-    #    actions:
-    #      $include: ./actions/ingestion/actions.config.yaml
-      webhook:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/webhook/actions.config.yaml
-      product-commerce:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/product/commerce/actions.config.yaml
-      product-backoffice:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/product/external/actions.config.yaml
-      customer-commerce:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/customer/commerce/actions.config.yaml
-      customer-backoffice:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/customer/external/actions.config.yaml
-      order-commerce:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/order/commerce/actions.config.yaml
-      order-backoffice:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/order/external/actions.config.yaml
-      stock-commerce:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/stock/commerce/actions.config.yaml
-      stock-backoffice:
-        license: Apache-2.0
-        actions:
-          $include: ./actions/stock/external/actions.config.yaml
-   ```
+   **Note:** The `info` action is enabled by default. This action helps us monitor the adoption of the Starter Kit. Please do not disable, remove, or rename the `info` action.
 
 #### Deploy the project
 

--- a/src/pages/starter-kit/create-integration.md
+++ b/src/pages/starter-kit/create-integration.md
@@ -158,9 +158,9 @@ In the Beta phase of the Starter Kit project, an Adobe Commerce representative w
    aio app use --merge
    ```
 
-1. The `app.config.yaml` in the repo's root directory defines which packages to deploy. The Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any packages that you do not need to deploy.
+1. The `app.config.yaml` in the repo's root directory defines which packages to deploy. The Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any unneeded packages that are not applicable to your project.
 
-   **Note:** The `info` action is enabled by default. This action helps us monitor the adoption of the Starter Kit. Please do not disable, remove, or rename the `info` action.
+   **Note:** The `info` action is enabled by default. This action is reserved for future use. Do not disable or delete the `info` action.
 
 #### Deploy the project
 

--- a/src/pages/starter-kit/create-integration.md
+++ b/src/pages/starter-kit/create-integration.md
@@ -158,7 +158,7 @@ In the Beta phase of the Starter Kit project, an Adobe Commerce representative w
    aio app use --merge
    ```
 
-1. The `app.config.yaml` in the repo's root directory defines which packages to deploy. The Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any unneeded packages that are not applicable to your project.
+1. The `app.config.yaml` file in the repo's root directory defines which packages to deploy. The Integration Starter Kit provides packages for Commerce products, customers, orders, shipments, and stocks and their external back office counterparts. Comment out any unneeded packages that are not applicable to your project.
 
    **Note:** The `info` action is enabled by default. This action is reserved for future use. Do not disable or delete the `info` action.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) mentions the info action and requests that it not be disabled or altered.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
