### PR TITLE
CEXT-3242: Release the new version of commerce webhooks without admin UI

### DIFF
--- a/src/pages/app-development/learning-path.md
+++ b/src/pages/app-development/learning-path.md
@@ -63,7 +63,6 @@ The following resources will help you get to know the extensibility options offe
   - [Setup and installation](https://developer.adobe.com/commerce/extensibility/webhooks/installation/) - Information on how to install Commerce modules necessary for implementing webhooks.
   - [Configuration](https://developer.adobe.com/commerce/extensibility/webhooks/hooks/) - Developer documentation on how to configure hooks for Adobe Commerce.
   - [Common use cases](https://developer.adobe.com/commerce/extensibility/webhooks/use-cases/) - Descriptions of common Adobe Commerce use cases for webhooks.
-  - [Webhooks](https://developer.adobe.com/commerce/extensibility/webhooks/admin-configuration/) - Learn how to extend, override, and create hooks using the Adobe Commerce Admin.
 
 ## Troubleshooting
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -13,7 +13,7 @@ These release notes describe the latest version of Adobe Commerce Webhooks.
 
 ### Release date
 
-May 15, 2024
+May 20, 2024
 
 ### Changes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) corrects the date of the webhooks release

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/#release-date

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
