### PR TITLE
cleanup

### DIFF
--- a/src/data/navigation/sections/starter-kit.js
+++ b/src/data/navigation/sections/starter-kit.js
@@ -16,11 +16,14 @@ module.exports = [
                 title: "Explore the structure",
                 path: "/starter-kit/structure.md"
             },
-            {
-                title: "Build & Customize",
-                header: true,
-                path: "/starter-kit/events.md"
-            },
+        ],
+    },
+    {
+        title: "Build & Customize",
+        header: true,
+        path: "/starter-kit/events.md",
+        pages: [
+
             {
                 title: "Event-based integrations",
                 path: "/starter-kit/events.md"   

--- a/src/pages/starter-kit/webhooks.md
+++ b/src/pages/starter-kit/webhooks.md
@@ -10,10 +10,7 @@ keywords:
  - Tools
 ---
 
-import BetaNote from '/src/_includes/starter-kit-beta.md'
 import actions from '/src/_includes/actions.md'
-
-<BetaNote />
 
 # Real-time integrations
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -17,7 +17,7 @@ May 20, 2024
 
 ### Changes
 
-* The Admin configuration UI for webhooks was removed as part of a security risk mitigation. Webhooks provide developer-oriented functionality and the Admin UI gave an unprecedented amount of access to admins, which could be inappropriate in some cases. All other webhooks functionality is still supported.
+The Admin configuration UI for webhooks was removed as part of a security risk mitigation. Webhooks provide developer-oriented functionality and the Admin UI gave an unprecedented amount of access to admins, which could be inappropriate in some cases. All other webhooks functionality is still supported.
 
 Upgrading to the latest version could impact existing webhooks. If you previously had webhooks that were created in the Admin UI, you must recreate them in an XML file. <!--CEXT-3241 -->
 


### PR DESCRIPTION
This PR removes a Beta note that was not addressed in https://github.com/AdobeDocs/commerce-extensibility/pull/201.

It also fixes "build and customize" in the left nav, which should be a header. 

It also fixes the alignment on a webhooks release note.