### PR TITLE
CEXT-3239: Remove webhooks admin UI

### DIFF
--- a/src/data/navigation/sections/webhooks.js
+++ b/src/data/navigation/sections/webhooks.js
@@ -32,10 +32,6 @@ module.exports = [
       path: "/webhooks/signature-verification.md"
     },
     {
-      title: "Admin configuration",
-      path: "/webhooks/admin-configuration.md"
-    },
-    {
       title: "Command reference",
       path: "/webhooks/commands.md",
     },


### PR DESCRIPTION
- remove a menu link

## Purpose of this pull request

This pull request (PR) will remove the link from the menu which no longer exists

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
