### PR TITLE
CEXT-3214: Fixing missing header and typos

### DIFF
--- a/src/pages/events/consume-events-examples/runtime-action-commerce-callback.md
+++ b/src/pages/events/consume-events-examples/runtime-action-commerce-callback.md
@@ -87,4 +87,4 @@ You can retrieve the `consumerKey`, `consumerSecret`, `accessToken`, and `access
 
 You can now add the order's extension attributes retrieved from Commerce to the order event payload, and send the payload to a third-party Enterprise Resource Planning (ERP) system using a custom module.
 
-After creating a runtime action using this code, you can create an event registration can to subscribe to the `observer.sales_order_save_after` event, and configure the new runtime action to receive the event notifications.
+After creating a runtime action using this code, you can create an event registration to subscribe to the `observer.sales_order_save_after` event and configure the new runtime action to receive the event notifications.

--- a/src/pages/events/consume-events.md
+++ b/src/pages/events/consume-events.md
@@ -17,7 +17,7 @@ You can consume events sent from Adobe Commerce to Adobe I/O events in several w
 
 ## Using the Journaling API
 
-When you create an Adobe I/O event registration, the subscribed events get added to an ordered list, referred to as the journal, by default. You can consume these events using a journaling endpoint URL that is unique to the registration. For more information on reading events from the journal, see the [Introduction to Journaling](https://developer.adobe.com/events/docs/guides/journaling_intro/).
+When you create an Adobe I/O event registration, by default, the subscribed events get added to an ordered list (referred to as the journal). You can consume these events using a journaling endpoint URL that is unique to the registration. For more information on reading events from the journal, see the [Introduction to Journaling](https://developer.adobe.com/events/docs/guides/journaling_intro/).
 
 You can also consume events from the Journaling API using the [Adobe I/O Events SDK](https://github.com/adobe/aio-lib-events). See [Subscribe to Events Using Journaling](https://developer.adobe.com/events/docs/guides/sdk/sdk_journaling/) for details and sample code.
 

--- a/src/pages/events/consume-events.md
+++ b/src/pages/events/consume-events.md
@@ -6,6 +6,8 @@ keywords:
   - Extensibility
 ---
 
+# Consume Events
+
 You can consume events sent from Adobe Commerce to Adobe I/O events in several ways. The following options for consuming events are available when adding events to your App Builder project and creating an event registration:
 
 * [Using the Journaling API](#using-the-journaling-api) (enabled by default)
@@ -15,7 +17,7 @@ You can consume events sent from Adobe Commerce to Adobe I/O events in several w
 
 ## Using the Journaling API
 
-When you create an Adobe I/O event registration, the subscribed events added to an ordered list, referred to as the journal, by default. You can consume these events using a journaling endpoint URL that is unique to the registration. For more information on reading events from the journal, see the [Introduction to Journaling](https://developer.adobe.com/events/docs/guides/journaling_intro/).
+When you create an Adobe I/O event registration, the subscribed events get added to an ordered list, referred to as the journal, by default. You can consume these events using a journaling endpoint URL that is unique to the registration. For more information on reading events from the journal, see the [Introduction to Journaling](https://developer.adobe.com/events/docs/guides/journaling_intro/).
 
 You can also consume events from the Journaling API using the [Adobe I/O Events SDK](https://github.com/adobe/aio-lib-events). See [Subscribe to Events Using Journaling](https://developer.adobe.com/events/docs/guides/sdk/sdk_journaling/) for details and sample code.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a missing header in the consume events page and fixes some small typos related to docs for consuming events

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/consume-events/
- https://developer.adobe.com/commerce/extensibility/events/consume-events-examples/runtime-action-commerce-callback/
## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
