### PR TITLE
CEXT-3355: Release commerce webhooks modules

### DIFF
--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,16 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.5.1
+
+### Release date
+
+July 10, 2024
+
+* Improved caching of webhook response during single request. <!--CEXT-3279 -->
+
+* Fixed a possible vulnerability issue with showing the public key in the Admin UI configuration page. <!--CEXT-3354 -->
+
 ## Version 1.5.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for commerce webhooks 1.5.1 release

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
