### PR TITLE
Add App Builder as a prereq

### DIFF
--- a/src/_includes/project-requirements.md
+++ b/src/_includes/project-requirements.md
@@ -1,3 +1,5 @@
 *  Have an Adobe Developer account with System Administrator or Developer Role permissions. [Getting started with Adobe Developer Console](https://developer.adobe.com/developer-console/docs/guides/getting-started/) describes how to enroll in the Adobe developer program.
 
+*  Have access to App Builder as described in [How to Get Access to App Builder](https://developer.adobe.com/app-builder/docs/overview/getting_access/). There could be a delay in processing access requests.
+
 *  Have access to an Adobe Commerce on cloud infrastructure or to an on-premises instance.

--- a/src/pages/starter-kit/create-integration.md
+++ b/src/pages/starter-kit/create-integration.md
@@ -41,8 +41,6 @@ Support services for the starter kit include the basic functionality and configu
 
 [Projects Overview](https://developer.adobe.com/developer-console/docs/guides/projects/) describes the different types of projects and how to manage them. Here, we'll create a templated project.
 
-Before you begin the onboarding process, you must be granted access to Adobe Developer App Builder. If you have not yet submitted a request, you might want to do that, as described at [How to Get Access to App Builder](https://developer.adobe.com/app-builder/docs/overview/getting_access/).
-
 1. Log in to the Adobe Developer Console and select the desired organization from the dropdown menu in the top-right corner.
 
 1. Click **Create new project from template**.

--- a/src/pages/starter-kit/create-integration.md
+++ b/src/pages/starter-kit/create-integration.md
@@ -41,11 +41,15 @@ Support services for the starter kit include the basic functionality and configu
 
 [Projects Overview](https://developer.adobe.com/developer-console/docs/guides/projects/) describes the different types of projects and how to manage them. Here, we'll create a templated project.
 
+Before you begin the onboarding process, you must be granted access to Adobe Developer App Builder. If you have not yet submitted a request, you might want to do that, as described at [How to Get Access to App Builder](https://developer.adobe.com/app-builder/docs/overview/getting_access/).
+
 1. Log in to the Adobe Developer Console and select the desired organization from the dropdown menu in the top-right corner.
 
 1. Click **Create new project from template**.
 
    ![Create a project](../_images/common/create-project.png)
+
+   If the **Create project from template** option is not displayed, it might be because your request to access App Builder has not yet been approved.
 
 1. Select **App Builder**. The **Set up templated project** page displays.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) mentions that you must have App Builder access to create a project. Added App Builder to the list of prereqs.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
