### PR TITLE
Fix typo

### DIFF
--- a/src/pages/starter-kit/ms-finance.md
+++ b/src/pages/starter-kit/ms-finance.md
@@ -43,4 +43,4 @@ This reference application uses starter kit [data flows](./data-flows.md) for th
 - **Order data flow**
   - Order and order flow
     - Adobe Commerce synchronizes new orders to D365 F&O
-    - Adobe Commerce synchronizes changes in order flow to Adobe Commerce
+    - D365 F&O synchronizes changes in order flow to Adobe Commerce


### PR DESCRIPTION
This PR fixes a typo on this page: https://developer.adobe.com/commerce/extensibility/starter-kit/ms-finance/