### PR TITLE
Update configuration page to add details on how to test locally pointing to a staging workspace

### DIFF
--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -164,6 +164,36 @@ You can download a sample app from the [Adobe Commerce Samples repository](https
 
 1. Change directories to `<repoRootDir>/admin-ui-sdk/menu/custom-menu`.
 
+1. Load dependencies running
+
+  ```bash
+  npm install
+  ```
+
+1. Select the project
+
+  ```bash
+  aio console project select
+  ```
+
+1. Select the workspace
+
+  ```bash
+  aio console workspace select
+  ```
+
+1. Sync the app builder project details
+
+  ```bash
+  aio app use
+  ```
+
+1. Build the solution
+
+  ```bash
+  aio app build
+  ```
+
 1. Run your custom menu extension locally.
 
    ```bash
@@ -175,3 +205,41 @@ You can download a sample app from the [Adobe Commerce Samples repository](https
    ![Fetched orders from Adobe Commerce page](../_images/first-app.png)
 
    ![First App on App Builder menu](../_images/fetched-orders.png)
+
+### Test using project workspaces
+
+To use a specific workspace from your project, you'll have to:
+
+1. Deploy the app to the workspace
+
+  ```bash
+  aio app deploy
+  ```
+
+  After deploy, you will see the URL to your app workspace under: `To view your deployed application:`
+
+1. Update the server `json_response` to point to your workspace by changing the app name and url
+
+  ```json
+  {
+    "name": "app_name",
+    "title": "Test extension",
+    "description": "No",
+    "icon": "no",
+    "publisher": "aQQ6300000008LEGAY",
+    "endpoints": {
+      "commerce/backend-ui/1": {
+        "view": [{
+          "href": "https://<app_workspace_url>/index.html"
+        }]
+      }
+    },
+    "xrInfo": {
+      "supportEmail": "test@adobe.com",
+      "appId": "4a4c7cf8-bd64-4649-b8ed-662cd0d9c918"
+    },
+    "status": "PUBLISHED" 
+  }
+  ```
+
+  You can add multiple workspaces to the server to test several applications at once.

--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -164,31 +164,31 @@ You can download a sample app from the [Adobe Commerce Samples repository](https
 
 1. Change directories to `<repoRootDir>/admin-ui-sdk/menu/custom-menu`.
 
-1. Load dependencies running
+1. Run the following command to load dependencies.
 
   ```bash
   npm install
   ```
 
-1. Select the project
+1. Select your App Builder project.
 
   ```bash
   aio console project select
   ```
 
-1. Select the workspace
+1. Select the App Builder workspace.
 
   ```bash
   aio console workspace select
   ```
 
-1. Sync the app builder project details
+1. Sync the App Builder project details.
 
   ```bash
   aio app use
   ```
 
-1. Build the solution
+1. Build your solution.
 
   ```bash
   aio app build

--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -208,17 +208,17 @@ You can download a sample app from the [Adobe Commerce Samples repository](https
 
 ### Test using project workspaces
 
-To use a specific workspace from your project, you'll have to:
+Use the following steps to test a specific workspace from your project:
 
-1. Deploy the app to the workspace
+1. Deploy the app to the workspace.
 
   ```bash
   aio app deploy
   ```
 
-  After deploy, you will see the URL to your app workspace under: `To view your deployed application:`
+  After deployment, the command displays the URL to your app workspace under `To view your deployed application:`
 
-1. Update the server `json_response` to point to your workspace by changing the app name and url
+1. Change the values of the `name` and `href` fields in the `json_response` section of the `server.js` file to point to your workspace.
 
   ```json
   {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to update the configuration page showcasing how to test on a local instance using a project workspace from app builder.

## Affected pages

- https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/configuration/

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
