### PR TITLE
Nav reorg for App Development Guide

### DIFF
--- a/src/data/navigation/sections/app-development.js
+++ b/src/data/navigation/sections/app-development.js
@@ -8,20 +8,18 @@ module.exports = [
         path: "/app-development/examples.md"   
     },
     {
-        title: "Learning path",
-        path: "/app-development/learning-path.md"   
-    },
-    {
-        title: "App development comparison",
-        path: "/app-development/app-development-comparison.md"   
-    },
-    {
-        title: "Services comparison",
-        path: "/app-development/services-comparison.md"   
-    },
-    {
-        title: "Port extensions to apps",
-        path: "/app-development/port-extensions.md"
+        title: "Porting extensions",
+        path: "/app-development/port-extensions.md",
+        pages: [
+            {
+                title: "App development comparison",
+                path: "/app-development/app-development-comparison.md"
+            },
+            {
+                title: "Services comparison",
+                path: "/app-development/services-comparison.md"   
+            },
+        ]
     },
     {
         title: "Best practices",
@@ -62,5 +60,9 @@ module.exports = [
             path: "/app-development/amazon-sales-channel/release-notes.md"
         }
     ]
-  }
+  },
+  {
+    title: "Learning path",
+    path: "/app-development/learning-path.md"   
+},
 ];

--- a/src/pages/app-development/port-extensions.md
+++ b/src/pages/app-development/port-extensions.md
@@ -12,56 +12,6 @@ Developers have traditionally used PHP to create in-process extensions that add 
 
 Adobe Developer App Builder uses out-of-process extensibility to avoid these compatibility issues. It provides a unified third-party extensibility framework for integrating and creating custom apps that extend Adobe Commerce. Since this extensibility framework is built on Adobe's infrastructure, developers can also extend Adobe Commerce with third-party systems.
 
-## How do I port an extension into an app?
-
-Start by becoming familiar with the [App Builder documentation](https://developer.adobe.com/app-builder/docs/overview/) and [create an Adobe developer account](https://developer.adobe.com/app-builder/docs/overview/getting_access/).
-
-Once you've become comfortable with the Adobe I/O infrastructure, analyze  your current extensions and begin mapping their in-process features into the App Builder and Adobe I/O environment. Key areas to consider include:
-
-*  Frontend development
-*  APIs
-*  Plugins and observers
-*  Backend development
-*  Custom cron jobs
-*  Database data
-*  Filesystem
-
-### Frontend development
-
-[Spectrum](https://spectrum.adobe.com/page/principles/) provides all the tools you need to create the next generation of React-based applications. You can use Spectrum UI components to build apps consistent with Adobe standards and leverage our SDK (#admin-development) to securely create custom app UIs in the Adobe Commerce Admin.
-
-Alternatively, you can use native HTML with CSS to create your UI components.
-
-<InlineAlert variant="info" slots="text"/>
-
-Adobe Commerce continues to support the [PWA Studio](https://developer.adobe.com/commerce/pwa-studio/) and [Luma](https://developer.adobe.com/commerce/frontend-core/) storefronts.
-
-### APIs
-
-[API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) enables developers to connect multiple APIs from Adobe Commerce, other Adobe products, and 3rd party sources into a single GraphQL endpoint. An orchestration layer transforms data from these disparate sources into the formats required to perform the tasks to fulfill business and user experience requirements.
-
-### Plugins and observers
-
-[Adobe I/O Events for Adobe Commerce](../events/index.md) enables building near real-time, event-driven Commerce integrations using App Builder. You can define key events, like customer account updates, to emit from Commerce and construct apps that listen and react to these events.
-
-[Adobe Commerce Webhooks](../webhooks/index.md) enables configuring synchronous logic to execute calls from Commerce to external systems when key events occur. You can use this real-time communication with external systems to validate or modify data in Commerce.
-
-### Admin development
-
-The [Adobe Commerce Admin UI SDK](../admin-ui-sdk/index.md) enables an App Builder developer to extend the [Commerce Admin](https://experienceleague.adobe.com/docs/commerce-admin/start/admin/admin.html) to include custom menus and pages.
-
-### Custom cron jobs
-
-App Builder uses Apache OpenWhisk Alarms to perform the scheduling services traditionally provided by cron jobs. [Scheduling Cron Jobs with Alarms](https://developer.adobe.com/app-builder/docs/resources/cron-jobs/) walks you through the process of implementing this feature.
-
-### Database data
-
-The [Adobe I/O Key/Value Storage library](https://github.com/adobe/aio-lib-state) is an npm module that provides a JavaScript abstraction on top of distributed/cloud databases with a simple key-value store state persistence API.
-
-### Filesystem
-
-The [Adobe I/O Files library](https://github.com/adobe/aio-lib-state) provides a JavaScript abstraction on top of cloud blob storages with a simple file-system like persistence API.
-
 ## Related information
 
 View the following tutorials for more information about using App Builder to build out-of-process apps:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adjusts the left nav of the App Development Guide

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
