### PR TITLE
docs: outline --force-deploy option for updating published application

### DIFF
--- a/src/pages/admin-ui-sdk/publish.md
+++ b/src/pages/admin-ui-sdk/publish.md
@@ -26,7 +26,13 @@ During the testing phase, an administrator of your enterprise organization perfo
 
 ## Update an already published application
 
-To update an already published application, you must revoke it and go through the approval process again.
+To deploy code changes to an already published application, you can perform a force deploy:
+
+```bash
+aio app deploy --force-deploy
+```
+
+To update the credentials or services used by an already published application, you must revoke it and go through the approval process again.
 
 1. Ask an enterprise organization administrator to revoke your published application in the [Adobe Exchange Manage panel](https://exchange.adobe.com/manage). Note that once revoked, your application will no longer be public.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) outlines how to use the `--force-deploy` option with the aio CLI to update an already published application.

It also outlines that the revoke + re-publish flow is still required for updating the credentials / services of an already published application.
