### PR TITLE
Migrating from application to extension and Admin UI SDK compatibility

### DIFF
--- a/src/pages/admin-ui-sdk/index.md
+++ b/src/pages/admin-ui-sdk/index.md
@@ -36,8 +36,6 @@ The [Adobe Commerce Samples repository](https://github.com/adobe/adobe-commerce-
 
 ## Admin UI SDK and Adobe Extensions
 
-[Extensions] (https://developer.adobe.com/app-builder/docs/guides/extensions/) are a new feature in Adobe App Builder that allows developers to integrate their applications with specific Adobe products in a more seamless and unified manner.
+Adobe App Builder supports [extensions](https://developer.adobe.com/app-builder/docs/guides/extensions/), which allow developers to integrate their applications with specific Adobe products, such as the Admin UI SDK. Extensions act as a bridge between Adobe products and the applications built using Adobe App Builder. As a result, these applications can be easily integrated and extended within Adobe's ecosystem.
 
-In essence, extensions act as a bridge between Adobe products and the applications built using Adobe App Builder, ensuring that these applications can be easily integrated and extended within Adobe's ecosystem.
-
-If you're [migrating] (https://developer.adobe.com/app-builder/docs/guides/extensions/extension_migration_guide/) an existing App Builder project that uses an `application` configuration in the `app.config.yaml` file to use an `extension` configuration, rest assured that this change will not cause any compatibility issues with your application and the Admin UI SDK. This switch is fully supported and will not affect your current application’s behavior.
+App Builder projects support `application` and `extension` configurations within the `app.config.yaml` file. The Admin UI SDK supports both of these types as well. The SDK is not affected if you [migrate](https://developer.adobe.com/app-builder/docs/guides/extensions/extension_migration_guide/) an existing App Builder project that uses an `application` configuration to use an `extension` configuration.

--- a/src/pages/admin-ui-sdk/index.md
+++ b/src/pages/admin-ui-sdk/index.md
@@ -33,3 +33,11 @@ The following sequence diagram illustrates the authentication process.
 ## Code samples
 
 The [Adobe Commerce Samples repository](https://github.com/adobe/adobe-commerce-samples/tree/main/admin-ui-sdk) contains samples for different extension points of the Adobe Commerce Admin UI SDK. Use these samples to gain insight on how the Admin SDK injects menus and pages into the Admin.
+
+## Admin UI SDK and Adobe Extensions
+
+[Extensions] (https://developer.adobe.com/app-builder/docs/guides/extensions/) are a new feature in Adobe App Builder that allows developers to integrate their applications with specific Adobe products in a more seamless and unified manner.
+
+In essence, extensions act as a bridge between Adobe products and the applications built using Adobe App Builder, ensuring that these applications can be easily integrated and extended within Adobe's ecosystem.
+
+If you're [migrating] (https://developer.adobe.com/app-builder/docs/guides/extensions/extension_migration_guide/) an existing App Builder project that uses an `application` configuration in the `app.config.yaml` file to use an `extension` configuration, rest assured that this change will not cause any compatibility issues with your application and the Admin UI SDK. This switch is fully supported and will not affect your current application’s behavior.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) intents to clearly state that switching from an application to an extension will not cause any issues. 

## Affected pages

https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
