### PR TITLE
CEXT-3976: Release commerce-webhooks 1.7.0

### DIFF
--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -19,7 +19,7 @@ December 18, 2024
 
 * Added webhook options to skip SSL certificate validation and to set the path to the certificate file. <!--CEXT-3914 -->
 
-* Fixed resource name to access webhook logs admin UI page. <!--CEXT-3782 -->
+* Fixed the resource name needed to access webhook logs in the Admin. <!--CEXT-3782 -->
 
 ## Version 1.6.0
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,18 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.7.0
+
+### Release date
+
+December 18, 2024
+
+### Enhancements
+
+* Added webhook options to skip SSL certificate validation and to set the path to the certificate file. <!--CEXT-3914 -->
+
+* Fixed resource name to access webhook logs admin UI page. <!--CEXT-3782 -->
+
 ## Version 1.6.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for commerce webhooks 1.7.0 release.

## Related PR

https://github.com/AdobeDocs/commerce-extensibility/pull/295

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
