### PR TITLE
CEXT-3459: Store event subscriptions in env.php

### DIFF
--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -136,11 +136,11 @@ bin/magento events:registrations:list -vv
 
 The `events:metadata:populate` command creates event metadata based on XML and application configurations. This metadata gets linked to the configured event provider.
 
-Event metadata is automatically created for new event subscriptions when you run the [`events:subscribe` command](#subscribe-to-an-event) and synchronize events registered in `io_events.xml` files or `config.php` when the `setup:upgrade` command runs. In the following situations, we recommend creating event metadata using the `events:metadata:populate` command:
+Event metadata is automatically created for new event subscriptions when you run the [`events:subscribe` command](#subscribe-to-an-event) and synchronize events registered in `io_events.xml`, `config.php` or `env.php` files when the `setup:upgrade` command runs. In the following situations, we recommend creating event metadata using the `events:metadata:populate` command:
 
 * You have configured an event provider after an `io_events.xml` file was pushed to your cloud instance and a redeployment has not occurred since this change.
 * You have not run `setup:upgrade` since adding an `io_events.xml` file to your on-premise instance.
-* You manually edited the event subscriptions configuration in `app/etc/config.php`.
+* You manually edited the event subscriptions configuration in `app/etc/config.php` or `app/etc/env.php`.
 
 As an alternative to running this command, you can click the **Execute Synchronization** button on the **General configuration** section of the Adobe I/O Events page in the Admin.
 
@@ -185,7 +185,7 @@ The command supports observer events by default. You must perform additional ste
 
 <InlineAlert variant="info" slots="text"/>
 
-You can also subscribe to a plugin event if it was registered in the `app/etc/config.php` file and subsequently unsubscribed with the [`events:unsubscribe` command](#unsubscribe-from-a-commerce-event). [Register events](./module-development.md#register-events) describes the format of these files.
+You can also subscribe to a plugin event if it was registered in the `app/etc/config.php` or `app/etc/env.php` files and subsequently unsubscribed with the [`events:unsubscribe` command](#unsubscribe-from-a-commerce-event). [Register events](./module-development.md#register-events) describes the format of these files.
 
 You can also create and subscribe to a conditional event. Conditional events allow you to determine the conditions that the Commerce events client module uses to emit native or custom events to your application. See [Create conditional events](./conditional-events.md) for detailed information and examples.
 
@@ -244,7 +244,7 @@ The subscription com.adobe.commerce.observer.catalog_product_save_after was succ
 
 ## Unsubscribe from a Commerce event
 
-The `events:unsubscribe` command causes the current provider to unsubscribe from the specified event. You cannot unsubscribe from events defined in a module's or root `etc/io_events.xml` file. However, you can unsubscribe events that were registered in the `app/etc/config.php` file or from the [`events:subscribe` command](#subscribe-to-an-event).
+The `events:unsubscribe` command causes the current provider to unsubscribe from the specified event. You cannot unsubscribe from events defined in a module's or root `etc/io_events.xml` file. However, you can unsubscribe events that were registered in the `app/etc/config.php` or `app/etc/env.php` files or from the [`events:subscribe` command](#subscribe-to-an-event).
 
 Use the [`events:list` command](#list-subscribed-commerce-events) to retrieve a list of subscribed events.
 

--- a/src/pages/events/conditional-events.md
+++ b/src/pages/events/conditional-events.md
@@ -90,7 +90,7 @@ These fields are present and declared in the parent event.
 
 The `bin/magento events:subscribe <event_code> --force --fields=<name1> --fields=<name2>` command creates and registers custom and native Commerce events. When you also specify the `--parent <event_code>` and `--rules=<field-name>|<operator>|<value>` options, you create and register a conditional event.
 
-The following command creates and registers the same conditional event shown in the `io_events.xml` example. Running the command also updates the system `config.php` file. If you need to subsequently update or delete the event subscription, you can manually update the event there. The `bin/magento events:unsubscribe` command unsubscribes the event, but it does not remove the command from the `config.php` file.
+The following command creates and registers the same conditional event shown in the `io_events.xml` example. Running the command also updates the system `env.php` file. If you need to subsequently update or delete the event subscription, you can manually update the event there. The `bin/magento events:unsubscribe` command unsubscribes the event, but it does not remove the subscription from the `env.php` file.
 
 ```bash
 bin/magento events:subscribe plugin.magento.catalog.model.resource_model.product.save_low_stock_event \

--- a/src/pages/events/configure-commerce.md
+++ b/src/pages/events/configure-commerce.md
@@ -36,7 +36,7 @@ You must configure Commerce to communicate with your project. Configuration incl
 
 1. Click **Save Config**, but do not leave the page. The next section creates an event provider, which is necessary to complete the configuration.
 
- The event provider will not appear in the Developer Console until after you subscribe to an event emitted by Commerce, such as `io_events.xml` or `config.php`.
+ The event provider will not appear in the Developer Console until after you subscribe to an event emitted by Commerce, such as `io_events.xml`, `env.php` or `config.php`.
 
 ## Create an event provider
 
@@ -135,8 +135,7 @@ Commerce provides two sources for events: observers and plugins. You must specif
    bin/magento events:subscribe observer.customer_login --fields=customer.firstname --fields=customer.lastname
    ```
 
-    **Warning**: When you use the `events:subscribe` command to subscribe to events on a Cloud environment, configuration information is stored in the `app/etc/config.php` file. You must keep in mind that this file can be replaced with the `app/etc/config.php` file from Git during deployment. As a result, the event subscription will be replaced as well.
-   To make these changes permanent, manually add the appropriate configuration to the `app/etc/config.php` file under Git.
+    **Note**: When you use the `events:subscribe` command to subscribe to events on a Cloud environment, configuration information is stored in the `app/etc/env.php` file.
 
    If you have a module ready or have specific events in mind, see [Register events](./module-development.md#register-events) for more information.
 

--- a/src/pages/events/convert-field-values.md
+++ b/src/pages/events/convert-field-values.md
@@ -101,7 +101,7 @@ The converter changes the payload to:
 
 ## Register the converter
 
-You must configure a module's `io_events.xml` or root `app/etc/io_events.xml` file to update the required fields. You can also declare them in the system `config.php` file or add them when using the CLI to subscribe to an event.
+You must configure a module's `io_events.xml` or root `app/etc/io_events.xml` file to update the required fields. You can also declare them in the system `env.php` or `config.php` files or add them when using the CLI to subscribe to an event.
 
 ### Command line
 

--- a/src/pages/events/custom-event-fields.md
+++ b/src/pages/events/custom-event-fields.md
@@ -12,7 +12,7 @@ Your custom module might generate data that would be useful to insert into an ex
 
 <InlineAlert variant="info" slots="text"/>
 
-You must configure a module's `io_events.xml` or root `app/etc/io_events.xml` file to add custom fields. You cannot declare them in the system `config.php` file or add them using the CLI.
+You must configure a module's `io_events.xml` or root `app/etc/io_events.xml` file to add custom fields. You cannot declare them in the system `config.php` or `env.php` files or add them using the CLI.
 
 ## Configure the `io_events.xml` file
 

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -29,7 +29,7 @@ You can use the Commerce Admin or the command line to find supported events and 
 You can programmatically register events using the following methods:
 
 *  Create an `io_events.xml` file in your module or in the root `app/etc` directory
-*  Declare them in the system `config.php` file
+*  Declare them in the system `env.php` of `config.php` files
 
 For each event you register, you must define which fields to transmit to your App Builder application. The payload of an event can be massive. In addition, some events include sensitive or PCI compliance data by default. The payload of the `observer.catalog_product_save_after` event is similar to the following:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information about storing event subscriptions in `env.php` file.

https://jira.corp.adobe.com/browse/CEXT-3459

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/commands/
- https://developer.adobe.com/commerce/extensibility/events/configure-commerce/
- https://developer.adobe.com/commerce/extensibility/events/convert-field-values/
- https://developer.adobe.com/commerce/extensibility/events/custom-event-fields/
- https://developer.adobe.com/commerce/extensibility/events/module-development/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
