### PR TITLE
CEXT: 3925 Added converter in the response of GET events subscriptions API call.

### DIFF
--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -110,17 +110,17 @@ The `GET /rest/all/V1/eventing/getEventSubscriptions` endpoint returns a list of
   "name": "observer.catalog_product_save_after.price_check",
   "parent": "observer.catalog_product_save_after",
   "fields": [
-		{
-			"name": "name",
-			"converter": "Magento\\CustomModule\\Model\\TestConverter"
-		},
-		{
-			"name": "price"
-		},
     {
-			"name": "sku"
-		}
-	],
+      "name": "name",
+      "converter": "Magento\\CustomModule\\Model\\TestConverter"
+    },
+    {
+      "name": "price"
+    },
+    {
+      "name": "sku"
+    }
+  ],
   "rules": [
     {
       "field": "price",

--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -110,10 +110,17 @@ The `GET /rest/all/V1/eventing/getEventSubscriptions` endpoint returns a list of
   "name": "observer.catalog_product_save_after.price_check",
   "parent": "observer.catalog_product_save_after",
   "fields": [
-    "price",
-    "name",
-    "sku"
-  ],
+		{
+			"name": "name",
+			"converter": "Magento\\CustomModule\\Model\\TestConverter"
+		},
+		{
+			"name": "price"
+		},
+    {
+			"name": "sku"
+		}
+	],
   "rules": [
     {
       "field": "price",


### PR DESCRIPTION
This pull request (PR) updates the response (added converter for the field) of the GET events subscriptions API call.

https://jira.corp.adobe.com/browse/CEXT-3925

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->
- https://developer.adobe.com/commerce/extensibility/events/api/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
