### PR TITLE
CEXT-4033: Eventing 1.11 & webhooks 1.8 release notes

### DIFF
--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -169,7 +169,7 @@ The `PUT /rest/<store_view_code>/V1/eventing/eventSubscribe/<event_name>` endpoi
     ],
     "destination": "string",
     "priority": true,
-    "hipaaAuditRequired": true
+    "hipaa_audit_required": true
   }
 }
 ```

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -387,9 +387,9 @@ The contents of the event are similar to the following:
 }
 ```
 
-### config.php
+### config.php and env.php
 
-You can also create an `io_events` section in the Commerce [`app/etc/config.php file`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/deployment-files.html). Events registered using this mechanism can be disabled from the command line.
+You can also create an `io_events` section in the Commerce [`app/etc/config.php file`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/deployment-files.html) or in the Commerce [`app/etc/env.php file`](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/files/deployment-files) beginning with **1.11.0** of Adobe I/O Events for Adobe Commerce. Events registered using this mechanism can be disabled from the command line.
 
 For example:
 

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -389,7 +389,7 @@ The contents of the event are similar to the following:
 
 ### config.php and env.php
 
-You can also create an `io_events` section in the Commerce [`app/etc/config.php file`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/deployment-files.html) or in the Commerce [`app/etc/env.php file`](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/files/deployment-files) beginning with **1.11.0** of Adobe I/O Events for Adobe Commerce. Events registered using this mechanism can be disabled from the command line.
+You can also create an `io_events` section in the Commerce [`app/etc/config.php file`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/deployment-files.html). As of version of **1.11.0** of Adobe I/O Events for Adobe Commerce, you can also create an `io_events section` in the Commerce [`app/etc/env.php file`](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/files/deployment-files). Events registered using this mechanism can be disabled from the command line.
 
 For example:
 

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,24 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.11.0
+
+### Release date
+
+January TBD, 2025
+
+### Enhancements
+
+* Event subscriptions created/updated via API or CLI now get stored in `env.php`. These subscriptions were previously stored in `config.php`. Event subscriptions remaining in `config.php` continue to be read by the modules to preserve backward compatibility. <!-- CEXT-3459 -->
+
+* Added the `GET /rest/<store_view_code>/V1/eventing/getEventSubscriptions` REST endpoint for retrieving a list of enabled event subscriptions. <!-- CEXT-3925, CEXT-4055, CEXT-4066 -->
+
+* Added the `PUT /rest/<store_view_code>/V1/eventing/eventSubscribe/{name}` REST endpoint for updating event subscriptions. <!-- CEXT-3974 -->
+
+* Added the `POST /rest/<store_view_code>/V1/eventing/eventUnsubscribe/{name}` REST endpoint for unsubscribing from events. <!-- CEXT-3975 -->
+
+* Event name prefix validation is now skipped when subscribing to an event with a parent name. <!-- CEXT-3989 -->
+
 ## Version 1.10.0
 
 ### Release date

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -16,7 +16,7 @@ See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io
 
 ### Release date
 
-January TBD, 2025
+January 23, 2025
 
 ### Enhancements
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,16 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.8.0
+
+### Release date
+
+January TBD, 2025
+
+### Enhancements
+
+* Added the `GET /rest/<store_view_code>/V1/webhooks/list` REST endpoint for retrieving a list of configured webhooks. <!-- CEXT-3925, CEXT-4068 -->
+
 ## Version 1.7.0
 
 ### Release date

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -13,7 +13,7 @@ These release notes describe the latest version of Adobe Commerce Webhooks.
 
 ### Release date
 
-January TBD, 2025
+January 23, 2025
 
 ### Enhancements
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -19,6 +19,10 @@ January TBD, 2025
 
 * Added the `GET /rest/<store_view_code>/V1/webhooks/list` REST endpoint for retrieving a list of configured webhooks. <!-- CEXT-3925, CEXT-4068 -->
 
+### Bug fix
+
+* Fixed an issue causing the `depth` option value to not impact the output of the `webhooks:info` command. <!-- CEXT-4102 --->
+
 ## Version 1.7.0
 
 ### Release date
@@ -47,7 +51,7 @@ October 30, 2024
 
 * Updated copyrights in the generated module files. <!--- CEXT-3508 -->
 
-## Bug fix
+### Bug fix
 
 * Fixed an issue causing `null` values to be returned in some payloads output by the `webhooks:info` command <!--CEXT-3608 -->
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for the eventing 1.11 and webhooks 1.8 releases.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/release-notes/
- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/
- https://developer.adobe.com/commerce/extensibility/events/module-development/
- https://developer.adobe.com/commerce/extensibility/events/api/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
