### PR TITLE
CEXT-4033: Remove visible ticket name from webhooks release notes

### DIFF
--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -21,7 +21,7 @@ January 23, 2025
 
 ### Bug fix
 
-* Fixed an issue causing the `depth` option value to not impact the output of the `webhooks:info` command. <!-- CEXT-4102 --->
+* Fixed an issue causing the `depth` option value to not impact the output of the `webhooks:info` command. <!-- CEXT-4102 -->
 
 ## Version 1.7.0
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a typo on the webhooks release notes page that causes an intended comment to be visible.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/release-notes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
