### PR TITLE
CEXT-4103: Document oope-shipping-methods module

### DIFF
--- a/src/pages/starter-kit/checkout/configure.md
+++ b/src/pages/starter-kit/checkout/configure.md
@@ -93,10 +93,22 @@ To run the script, ensure you have completed the following steps:
 
 This script must finish running before you deploy the application for event registration.
 
+**Note**: To run the scripts below, you must first configure the [Adobe Commerce HTTP Client](./connect.md#connect-to-adobe-commerce).
+
 ### create-payment-methods
 
 The [`create-payment-methods`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-payment-methods.js) script creates payment methods in Adobe Commerce.
 
 It reads the payment methods configuration from the `payment-methods.yaml` file and creates the payment methods in Adobe Commerce.
 
-To run the `create-payment-methods` script, you must first configure the [Adobe Commerce HTTP Client](./connect.md#connect-to-adobe-commerce).
+### create-shipping-carriers
+
+To be able to add the shipping methods to the Adobe Commerce instance using webhooks, you must first create the shipping carriers.
+
+The [`create-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-shipping-carriers.js) script creates shipping carriers in Adobe Commerce.
+
+It reads the shipping carriers configuration from the `shipping-carriers.yaml` file and creates the shipping carriers in Adobe Commerce.
+
+### get-shipping-carriers
+
+To retrieve the shipping carriers from the Adobe Commerce instance, you can use the [`get-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/get-shipping-carriers.js) script.

--- a/src/pages/starter-kit/checkout/configure.md
+++ b/src/pages/starter-kit/checkout/configure.md
@@ -93,7 +93,9 @@ To run the script, ensure you have completed the following steps:
 
 This script must finish running before you deploy the application for event registration.
 
-**Note**: To run the scripts below, you must first configure the [Adobe Commerce HTTP Client](./connect.md#connect-to-adobe-commerce).
+<InlineAlert variant="info" slots="text"/>
+
+To run the following scripts, you must configure the [Adobe Commerce HTTP Client](./connect.md#connect-to-adobe-commerce).
 
 ### create-payment-methods
 
@@ -103,12 +105,10 @@ It reads the payment methods configuration from the `payment-methods.yaml` file 
 
 ### create-shipping-carriers
 
-To be able to add the shipping methods to the Adobe Commerce instance using webhooks, you must first create the shipping carriers.
+To add shipping methods to the Adobe Commerce instance using webhooks, you must first create shipping carriers.
 
-The [`create-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-shipping-carriers.js) script creates shipping carriers in Adobe Commerce.
-
-It reads the shipping carriers configuration from the `shipping-carriers.yaml` file and creates the shipping carriers in Adobe Commerce.
+The [`create-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-shipping-carriers.js) script creates shipping carriers in Adobe Commerce, by reading the shipping carriers configuration from `shipping-carriers.yaml`.
 
 ### get-shipping-carriers
 
-To retrieve the shipping carriers from the Adobe Commerce instance, you can use the [`get-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/get-shipping-carriers.js) script.
+To retrieve shipping carriers from Commerce, use the [`get-shipping-carriers`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/get-shipping-carriers.js) script.

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -21,7 +21,8 @@ To begin using the checkout starter kit, ensure that your Adobe Commerce install
 
 - Install the Out-of-Process Shipping Extensions (OOPE) Module in Adobe Commerce
 
-  To enable out-of-process shipping methods in Adobe Commerce, install the `magento/module-out-of-process-shipping-methods`. This module enables out-of-process shipping methods functionalities.
+  To enable out-of-process shipping methods in Adobe Commerce, install the `magento/module-out-of-process-shipping-methods` module.
+
   To install the module, run the following command using Composer:
 
     ```bash

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -19,6 +19,15 @@ To begin using the checkout starter kit, ensure that your Adobe Commerce install
     composer require magento/module-out-of-process-payment-methods --with-dependencies
     ```
 
+- Install the Out-of-Process Shipping Extensions (OOPE) Module in Adobe Commerce
+
+  To enable out-of-process shipping methods in Adobe Commerce, install the `magento/module-out-of-process-shipping-methods`. This module enables out-of-process shipping methods functionalities.
+  To install the module, run the following command using Composer:
+
+    ```bash
+    composer require magento/module-out-of-process-shipping-methods --with-dependencies
+    ```
+
 - Install the Commerce Eventing Module
 
     The [Commerce Eventing module](https://developer.adobe.com/commerce/extensibility/events/) is crucial for handling events within Adobe Commerce. The eventing module is installed automatically in Adobe Commerce version `2.4.6` and higher.

--- a/src/pages/starter-kit/checkout/reference.md
+++ b/src/pages/starter-kit/checkout/reference.md
@@ -254,6 +254,7 @@ try {
   return errorResponse(HTTP_INTERNAL_ERROR, 'Error occurred while creating shipping carrier');
 }
 ```
+
 #### Example response
 
 ```json
@@ -280,6 +281,7 @@ try {
 <CodeBlock slots="heading, code" repeat="2" languages="javascript, json" />
 
 #### Example usage
+
 ```javascript
 try {
   const listResponse = await commerceClient.getOopeShippingCarriers();

--- a/src/pages/starter-kit/checkout/reference.md
+++ b/src/pages/starter-kit/checkout/reference.md
@@ -210,3 +210,166 @@ try {
   return errorResponse(HTTP_INTERNAL_ERROR, 'Failed to fetch order due to an unexpected error');
 }
 ```
+
+## Create a new OOPE shipping carrier
+
+`createOopeShippingCarrier` creates a new out-of-process shipping carrier with the necessary details such as `code`, `title`, and `configuration`.
+
+**Payload parameters:**
+
+| Parameter                   | Type    | Description                                                             |
+| --------------------------- | ------- | ----------------------------------------------------------------------- |
+| `code`                      | String  | Unique identifier for the shipping carrier.                             |
+| `title`                     | String  | Display name of the shipping carrier.                                   |
+| `stores`                    | Array   | List of store codes that the shipping carrier is available              |
+| `countries`                 | Array   | List of countries where the shipping carrier is available.              |
+| `active`                    | Boolean | Status indicating if the shipping carrier is active.                    |
+| `sort_order`                | Integer | The sort order of shipping carriers.                                    |
+| `tracking_available`        | Boolean | Status indicating if the shipping carrier has available tracking.       |
+| `shipping_labels_available` | Boolean | Status indicating if the shipping carrier has available sipping labels. |
+
+
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+
+#### Example usage
+
+```javascript
+try {
+  const createResponse = await commerceClient.createOopeShippingCarrier({
+    code: 'DPS',
+    title: 'Demo Postal Service',
+    stores: ['default'],
+    countries: ['US', 'CA'],
+    active: true,
+    sort_order: 10,
+    tracking_available: true,
+    shipping_labels_available: true,
+  });
+
+  if (!createResponse.success) {
+    return errorResponse(createResponse.statusCode, 'Failed to create shipping carrier');
+  }
+
+  console.log('Created shipping carrier:', createResponse.message);
+} catch (error) {
+  return errorResponse(HTTP_INTERNAL_ERROR, 'Error occurred while creating shipping carrier');
+}
+```
+
+
+#### Example response
+
+```json
+{
+  "success": true,
+  "message": {
+    "id": 1,
+    "code": "DPS",
+    "title": "Demo Postal Service",
+    "stores": ["default"],
+    "countries": ["US", "CA"],
+    "active": true,
+    "sort_order": 10,
+    "tracking_available": true,
+    "shipping_labels_available": true
+  }
+}
+```
+
+## List all shipping carriers
+
+`getOopeShippingCarriers` retrieves a list of all out-of-process shipping carriers in the Adobe Commerce instance.
+
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+
+#### Example usage
+
+
+```javascript
+try {
+  const listResponse = await commerceClient.getOopeShippingCarriers();
+  if (!listResponse.success) {
+    return errorResponse(listResponse.statusCode, 'Failed to list shipping carriers');
+  }
+  console.log('List of shipping carriers:', listResponse.message);
+} catch (error) {
+  return errorResponse(HTTP_INTERNAL_ERROR, 'Error occurred while listing shipping carriers');
+}
+```
+
+#### Example response
+
+```json
+{
+  "success": true,
+  "message": [
+    {
+      "id": 1,
+      "code": "DPS",
+      "title": "Demo Postal Service",
+      "stores": ["default"],
+      "countries": ["US", "CA"],
+      "sort_order": 10,
+      "active": true,
+      "tracking_available": true,
+      "shipping_labels_available": true
+    },
+    {
+      "id": 2,
+      "code": "Fedex",
+      "title": "Fedex Service",
+      "stores": ["default"],
+      "countries": ["US"],
+      "sort_order": 50,
+      "active": true,
+      "tracking_available": false,
+      "shipping_labels_available": true
+    }
+  ]
+}
+```
+
+## Get an OOPE shipping carrier by code
+
+`getOopeShippingCarrier` retrieves one out-of-process shipping carrier by code from the Adobe Commerce instance.
+
+**Payload parameters:**
+
+| Parameter | Type   | Description                                 |
+| --------- | ------ | ------------------------------------------- |
+| `code`    | String | Unique identifier for the shipping carrier. |
+
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+
+#### Example usage
+
+```javascript
+try {
+  const getResponse = await commerceClient.getOopeShippingCarrier('DPS');
+  if (!getResponse.success) {
+    return errorResponse(getResponse.statusCode, 'Failed to retrieve shipping carrier');
+  }
+  console.log('Retrieved shipping carrier details:', getResponse.message);
+} catch (error) {
+  return errorResponse(HTTP_INTERNAL_ERROR, 'Error occurred while retrieving shipping carrier');
+}
+```
+
+#### Example response
+
+```json
+{
+  "success": true,
+  "message": {
+    "id": 1,
+    "code": "DPS",
+    "title": "Demo Postal Service",
+    "stores": ["default"],
+    "countries": ["US", "CA"],
+    "sort_order": 10,
+    "active": true,
+    "tracking_available": true,
+    "shipping_labels_available": true
+  }
+}
+```

--- a/src/pages/starter-kit/checkout/reference.md
+++ b/src/pages/starter-kit/checkout/reference.md
@@ -221,15 +221,13 @@ try {
 | --------------------------- | ------- | ----------------------------------------------------------------------- |
 | `code`                      | String  | Unique identifier for the shipping carrier.                             |
 | `title`                     | String  | Display name of the shipping carrier.                                   |
-| `stores`                    | Array   | List of store codes that the shipping carrier is available              |
+| `stores`                    | Array   | List of store codes where the shipping carrier is available.              |
 | `countries`                 | Array   | List of countries where the shipping carrier is available.              |
 | `active`                    | Boolean | Status indicating if the shipping carrier is active.                    |
 | `sort_order`                | Integer | The sort order of shipping carriers.                                    |
 | `tracking_available`        | Boolean | Status indicating if the shipping carrier has available tracking.       |
-| `shipping_labels_available` | Boolean | Status indicating if the shipping carrier has available sipping labels. |
-
-
-<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+| `shipping_labels_available` | Boolean | Status indicating if the shipping carrier has available shipping labels. |
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, json" />
 
 #### Example usage
 
@@ -255,8 +253,6 @@ try {
   return errorResponse(HTTP_INTERNAL_ERROR, 'Error occurred while creating shipping carrier');
 }
 ```
-
-
 #### Example response
 
 ```json
@@ -280,11 +276,9 @@ try {
 
 `getOopeShippingCarriers` retrieves a list of all out-of-process shipping carriers in the Adobe Commerce instance.
 
-<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, json" />
 
 #### Example usage
-
-
 ```javascript
 try {
   const listResponse = await commerceClient.getOopeShippingCarriers();
@@ -331,7 +325,7 @@ try {
 
 ## Get an OOPE shipping carrier by code
 
-`getOopeShippingCarrier` retrieves one out-of-process shipping carrier by code from the Adobe Commerce instance.
+`getOopeShippingCarrier` retrieves one out-of-process shipping carrier by `code` from the Adobe Commerce instance.
 
 **Payload parameters:**
 
@@ -339,7 +333,7 @@ try {
 | --------- | ------ | ------------------------------------------- |
 | `code`    | String | Unique identifier for the shipping carrier. |
 
-<CodeBlock slots="heading, code" repeat="2" languages="javascript, javascript" />
+<CodeBlock slots="heading, code" repeat="2" languages="javascript, json" />
 
 #### Example usage
 

--- a/src/pages/starter-kit/checkout/reference.md
+++ b/src/pages/starter-kit/checkout/reference.md
@@ -217,16 +217,17 @@ try {
 
 **Payload parameters:**
 
-| Parameter                   | Type    | Description                                                             |
-| --------------------------- | ------- | ----------------------------------------------------------------------- |
-| `code`                      | String  | Unique identifier for the shipping carrier.                             |
-| `title`                     | String  | Display name of the shipping carrier.                                   |
-| `stores`                    | Array   | List of store codes where the shipping carrier is available.              |
-| `countries`                 | Array   | List of countries where the shipping carrier is available.              |
-| `active`                    | Boolean | Status indicating if the shipping carrier is active.                    |
-| `sort_order`                | Integer | The sort order of shipping carriers.                                    |
-| `tracking_available`        | Boolean | Status indicating if the shipping carrier has available tracking.       |
-| `shipping_labels_available` | Boolean | Status indicating if the shipping carrier has available shipping labels. |
+| Parameter                   | Type    | Required | Description                                                              |
+|-----------------------------|---------|----------|--------------------------------------------------------------------------|
+| `code`                      | String  | Yes      | Unique identifier for the shipping carrier.                              |
+| `title`                     | String  | Yes      | Display name of the shipping carrier.                                    |
+| `stores`                    | Array   | No       | List of store codes where the shipping carrier is available.             |
+| `countries`                 | Array   | No       | List of countries where the shipping carrier is available.               |
+| `active`                    | Boolean | No       | Status indicating if the shipping carrier is active.                     |
+| `sort_order`                | Integer | No       | The sort order of shipping carriers.                                     |
+| `tracking_available`        | Boolean | No       | Status indicating if the shipping carrier has available tracking.        |
+| `shipping_labels_available` | Boolean | No       | Status indicating if the shipping carrier has available shipping labels. |
+
 <CodeBlock slots="heading, code" repeat="2" languages="javascript, json" />
 
 #### Example usage

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -168,22 +168,6 @@ The following example demonstrates how to add a webhook to the `plugin.magento.o
 </config>
 ```
 
-Alternatively, you can navigate to **System > Webhooks** in the Adobe Commerce Admin and create a new webhook with the following configuration:
-
-```yaml
-Hook Settings:
-  Webhook Method: plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates
-  Webhook Type: after
-  Batch Name: shipping_methods
-  Hook Name: oope_shipping_methods_carrier_one
-  URL: https://<yourappbuilder>.runtime.adobe.io/api/v1/web/commerce-checkout-starter-kit/shipping-methods
-  Active: Yes
-  Method: POST
-
-Hook Fields:
-  Field: rateRequest
-```
-
 You can register multiple webhooks for different shipping methods or shipping carriers by adding them into the same batch to ensure they are executed in parallel or create multiple batches to execute them sequentially.
 
 ## Shipping methods: GraphQL

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -170,17 +170,17 @@ The following example demonstrates how to add a webhook to the `plugin.magento.o
 
 Alternatively, you can navigate to **System > Webhooks** in the Adobe Commerce Admin and create a new webhook with the following configuration:
 
-```
-Hook Settings
+```yaml
+Hook Settings:
   Webhook Method: plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates
   Webhook Type: after
-  Batch Name shipping_methods
+  Batch Name: shipping_methods
   Hook Name: oope_shipping_methods_carrier_one
   URL: https://<yourappbuilder>.runtime.adobe.io/api/v1/web/commerce-checkout-starter-kit/shipping-methods
   Active: Yes
   Method: POST
 
-Hook Fields
+Hook Fields:
   Field: rateRequest
 ```
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -140,13 +140,13 @@ Refer to [`actions/validate-payment.js`](https://github.com/adobe/commerce-check
 
 ## Shipping methods
 
-The shipping methods can be added to the checkout process by using the [Adobe Commerce Webhook](../../webhooks/index.md) functionality.
+You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md).
 
 After the webhook is registered, every time a shopping cart is requested, a synchronous call is dispatched to the App Builder application implementing the shipping method to calculate the shipping cost and provide the available shipping methods.
 
 Refer to [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js) for an example of how to process the request and return the list of available shipping methods.
 
-To register a webhook, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root app/etc directory.
+To register a webhook, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
 
 The following example demonstrates how to add a webhook to the `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` method:
 
@@ -168,7 +168,7 @@ The following example demonstrates how to add a webhook to the `plugin.magento.o
 </config>
 ```
 
-Or to navigate to **System > Webhooks** in the Adobe Commerce Admin and create a new webhook with the following configuration:
+Alternatively, you can navigate to **System > Webhooks** in the Adobe Commerce Admin and create a new webhook with the following configuration:
 
 ```
 Hook Settings
@@ -188,9 +188,9 @@ You can register multiple webhooks for different shipping methods or shipping ca
 
 ## Shipping methods: GraphQL
 
-In the `setShippingAddressesOnCart` the available shipping methods that are returned by the webhook are appended to the `available_shipping_methods` field.
+In `setShippingAddressesOnCart` available shipping methods that are returned by the webhook are appended to the `available_shipping_methods` field.
 
-You can use the `additional_data` field to pass additional information about the shipping method from the webhook. The `additional_data` field is an array of key-value pairs that can be useful for passing additional information about the shipping method.
+You can use the `additional_data` field to pass an array of key-value pairs to provide additional information about the shipping method from the webhook.```
 
 ```json
 {
@@ -282,7 +282,7 @@ You can use the `additional_data` field to pass additional information about the
 }
 ```
 
-In the `setShippingMethodsOnCart` mutation you can set the shipping method provided by webhook, it's information will be stored in the `selected_shipping_method` field with the `additional_data` if provided.
+In the `setShippingMethodsOnCart` mutation you can set the shipping method provided by webhook, its information is stored in the `selected_shipping_method` field with the `additional_data` if provided.
 
 ```json
 {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information on configuring out-of-process shipping methods.

https://jira.corp.adobe.com/browse/CEXT-4103

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer-stage.adobe.com/commerce/extensibility/starter-kit/checkout/use-cases/
- https://developer-stage.adobe.com/commerce/extensibility/starter-kit/checkout/getting-started/
- https://developer-stage.adobe.com/commerce/extensibility/starter-kit/checkout/structure/
- https://developer-stage.adobe.com/commerce/extensibility/starter-kit/checkout/reference/

## Related PR 

https://github.com/adobe/commerce-checkout-starter-kit/pull/7

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
