### PR TITLE
checkout starter kit feedback

### DIFF
--- a/src/data/navigation/sections/checkout-starter-kit.js
+++ b/src/data/navigation/sections/checkout-starter-kit.js
@@ -1,46 +1,53 @@
 module.exports = [
     {
-        title: 'Introduction',
-        path: '/starter-kit/checkout/index.md',
-    },
-    {
-        title: 'Use cases',
-        path: '/starter-kit/checkout/use-cases/',
-    },
-    {
-        title: 'Getting started',
-        path: '/starter-kit/checkout/getting-started.md',
-    },
-    {
-        title: 'Configure',
-        path: '/starter-kit/checkout/configure/',
-    },
-    {
-        title: 'Connect to Adobe Commerce',
-        path: '/starter-kit/checkout/connect/',
-    },
-    {
-        title: 'Integrate with an EDS storefront',
-        path: '/starter-kit/checkout/eds/',
-    },
-    {
-        title: 'CI/CD',
-        path: '/starter-kit/checkout/cicd/',
-    },
-    {
-        title: 'Development',
-        path: '/starter-kit/checkout/development/',
-    },
-    {
-        title: 'Payment API Javascript usage',
-        path: '/starter-kit/checkout/payment-usage/',
-    },
-    {
-        title: 'Payment API reference',
-        path: '/starter-kit/checkout/payment-reference/',
-    },
-    {
-        title: 'Shipping API reference',
-        path: '/starter-kit/checkout/shipping-reference/',
+        title: "Checkout starter kit",
+        header: true,
+        path: "/starter-kit/checkout/index.md",
+        pages: [
+            {
+                title: 'Introduction',
+                path: '/starter-kit/checkout/index.md',
+            },
+            {
+                title: 'Use cases',
+                path: '/starter-kit/checkout/use-cases/',
+            },
+            {
+                title: 'Getting started',
+                path: '/starter-kit/checkout/getting-started.md',
+            },
+            {
+                title: 'Configure',
+                path: '/starter-kit/checkout/configure/',
+            },
+            {
+                title: 'Connect to Adobe Commerce',
+                path: '/starter-kit/checkout/connect/',
+            },
+            {
+                title: 'Integrate with an EDS storefront',
+                path: '/starter-kit/checkout/eds/',
+            },
+            {
+                title: 'CI/CD',
+                path: '/starter-kit/checkout/cicd/',
+            },
+            {
+                title: 'Development',
+                path: '/starter-kit/checkout/development/',
+            },
+            {
+                title: 'Payment API Javascript usage',
+                path: '/starter-kit/checkout/payment-usage/',
+            },
+            {
+                title: 'Payment API reference',
+                path: '/starter-kit/checkout/payment-reference/',
+            },
+            {
+                title: 'Shipping API reference',
+                path: '/starter-kit/checkout/shipping-reference/',
+            }
+        ],
     },
 ];

--- a/src/data/navigation/sections/integration-starter-kit.js
+++ b/src/data/navigation/sections/integration-starter-kit.js
@@ -1,6 +1,6 @@
 module.exports = [
     {
-        title: "Create",
+        title: "Integration starter kit",
         header: true,
         path: "/starter-kit/integration/index.md",
         pages: [
@@ -8,6 +8,13 @@ module.exports = [
                 title: "Overview",
                 path: "/starter-kit/integration/"
             },
+        ],
+    },
+    {
+        title: "Create",
+        header: true,
+        path: "/starter-kit/integration/index.md",
+        pages: [
             {
                 title: "Installation",
                 path: "/starter-kit/integration/create-integration.md"
@@ -124,12 +131,6 @@ module.exports = [
                 title: "Code samples",
                 path: "https://github.com/adobe/adobe-commerce-samples/tree/main/starter-kit"
             },
-            /*
-            {
-                title: "Contact us",
-                path: "/starter-kit/integration/contact-us.md"
-            }
-            */
         ]
     }
 ];

--- a/src/pages/starter-kit/checkout/index.md
+++ b/src/pages/starter-kit/checkout/index.md
@@ -8,7 +8,7 @@ keywords:
 
 # Adobe Commerce checkout starter kit
 
-The Checkout starter kit helps you get started building custom checkout experiences for Adobe Commerce. It demonstrates how to use Adobe Commerce extensibility in combination with Adobe Developer App Builder to build custom checkout experiences.
+The checkout starter kit helps you get started building custom checkout experiences for Adobe Commerce. It demonstrates how to use Adobe Commerce extensibility in combination with Adobe Developer App Builder to build custom checkout experiences.
 
 Refer to the [Getting Started](./getting-started.md) page to learn how to set up the starter kit.
 


### PR DESCRIPTION
This PR addresses feedback by adding a header to the left nav that indicates which starter kit you are viewing.

I've also added a similar heading for the integration starter kit.

staging: https://developer-stage.adobe.com/commerce/extensibility/starter-kit/checkout/
