### PR TITLE
CEXT-4264: Add the possibility of disabling shipping methods

### DIFF
--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -170,6 +170,12 @@ The following example demonstrates how to add a webhook to the `plugin.magento.o
 
 You can register multiple webhooks for different shipping methods or shipping carriers by adding them into the same batch to ensure they are executed in parallel or create multiple batches to execute them sequentially.
 
+### Remove shipping method
+
+The `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` webhook within adding shipping methods allows you to remove specific shipping methods from the list of available options
+
+For example, if you are using the `flatrate` shipping method but certain conditions require it to be disallowed, you need to update your webhook response to mark the shipping method as removed. You can find an example in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
+
 ## Shipping methods: Payload
 
 The request payload contains information about all items in the cart, including product information, product attributes, shipping address, and customer information for logged-in customers.

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -172,9 +172,9 @@ You can register multiple webhooks for different shipping methods or shipping ca
 
 ### Remove shipping method
 
-The `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` webhook within adding shipping methods allows you to remove specific shipping methods from the list of available options
+The `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` webhook allows you to remove specific shipping methods from the list of available options.
 
-For example, if you are using the `flatrate` shipping method but certain conditions require it to be disallowed, you need to update your webhook response to mark the shipping method as removed. You can find an example in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
+If you use the `flatrate` shipping method, but want to disable it, you must update your webhook response to mark the shipping method as removed. This example is demonstrated in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
 
 ## Shipping methods: Payload
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds information that shipping methods can be removed by using oope shipping methods webhook.
https://jira.corp.adobe.com/browse/CEXT-4264

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/ 

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
