### PR TITLE
CEXT-4373: Update the oope shipping methods documentation

### DIFF
--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -29,7 +29,7 @@ You must install or have access to the following prerequisites to develop with t
 
 ## Install Commerce modules
 
-Before installing modules ensure that you have the required credentials in your `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
+Before installing Commerce modules, ensure that you have the required credentials in `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
 
 - Install the Out-of-Process Payment Extensions (OOPE) module on Adobe Commerce
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -29,6 +29,8 @@ You must install or have access to the following prerequisites to develop with t
 
 ## Install Commerce modules
 
+Before installing modules ensure that you have the required credentials in your `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
+
 - Install the Out-of-Process Payment Extensions (OOPE) module on Adobe Commerce
 
     To enable out-of-process payment methods in Commerce, install the `magento/module-out-of-process-payment-methods`. This module enables out-of-process payment functionalities.

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -211,7 +211,7 @@ You can find examples of how to filter out payment methods using customer data o
 
 ## Shipping methods
 
-You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md). 
+You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md).
 
 To be able to add shipping methods, you must first [run a script to automatically create shipping carriers](./configure.md#create-shipping-carriers) or [to create shipping carriers manually](./shipping-reference.md#shipping-api-reference) using REST Api. Only shipping methods with the registered carriers for them will be available in the checkout process.
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -211,7 +211,9 @@ You can find examples of how to filter out payment methods using customer data o
 
 ## Shipping methods
 
-You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md).
+You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md). 
+
+To be able to add shipping methods, you must first [run a script to automatically create shipping carriers](./configure.md#create-shipping-carriers) or [to create shipping carriers manually](./shipping-reference.md#shipping-api-reference) using REST Api. Only shipping methods with the registered carriers for them will be available in the checkout process.
 
 After the webhook is registered, every time a shopping cart is requested, a synchronous call is dispatched to the App Builder application implementing the shipping method to calculate the shipping cost and provide the available shipping methods.
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -213,7 +213,7 @@ You can find examples of how to filter out payment methods using customer data o
 
 You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md).
 
-To be able to add shipping methods, you must first [run a script to automatically create shipping carriers](./configure.md#create-shipping-carriers) or [to create shipping carriers manually](./shipping-reference.md#shipping-api-reference) using REST Api. Only shipping methods with the registered carriers for them will be available in the checkout process.
+To add shipping methods, you must [run a script to automatically create shipping carriers](./configure.md#create-shipping-carriers) or [create shipping carriers manually](./shipping-reference.md#shipping-api-reference) using the REST API. Only shipping methods with registered carriers are available in the checkout process.
 
 After the webhook is registered, every time a shopping cart is requested, a synchronous call is dispatched to the App Builder application implementing the shipping method to calculate the shipping cost and provide the available shipping methods.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds:

-  information about the requirement of having valid credentials in auth.json before installing oope modules. 
-  information about shipping carrier configuration before adding oope shipping methods

https://jira.corp.adobe.com/browse/CEXT-4373

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/getting-started/
- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/use-cases/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
