### PR TITLE
Add domain to skipUrlPatterns

### DIFF
--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -26,7 +26,8 @@ const remarkConfig = {
 			{
 				skipUrlPatterns: [
 					"https://www.php.net",
-					"https://helpx.adobe.com/enterprise/using/manage-developers.html"
+					"https://helpx.adobe.com/enterprise/using/manage-developers.html",
+					'https://developer.adobe.com/developer-console/*'
 				]
 			}
 		]


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds `https://developer.adobe.com/developer-console/*` to the `skipUrlPatterns` section of the `.remarkrc.mjs` file. Skipping this domain allows to avoid failures of the link checking test related to the temporary bug on the website until it's fixed.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
