### PR TITLE
Badging for starter kits

### DIFF
--- a/src/pages/starter-kit/checkout/connect.md
+++ b/src/pages/starter-kit/checkout/connect.md
@@ -69,5 +69,3 @@ This option allows communication between Commerce and App Builder.
 ## Debugging requests
 
 After following one of the connection options above, you can debug your application and access customized logs using the `LOG_LEVEL` environment variable. If this variable is set, logs from different phases of the commerce client display with detailed information.
-
-<!-- What are options for log level variable??? -->

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -33,6 +33,8 @@ You must install or have access to the following prerequisites to develop with t
 
 Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring their local environment](#initial-configuration) or [configuring Commerce](./configure.md).
 
+<Edition name="paas" />
+
 Before installing Commerce modules, ensure that you have the required credentials in `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
 
 - Install the Out-of-Process Payment Extensions (OOPE) module on Adobe Commerce

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -31,7 +31,7 @@ You must install or have access to the following prerequisites to develop with t
 
 <InlineAlert variant="info" slots="text"/>
 
-Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring their local environment](#initial-configuration) or [configuring events](./configure.md#configure-events).
+Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring their local environment](#initial-configuration) or [configuring Commerce](./configure.md).
 
 Before installing Commerce modules, ensure that you have the required credentials in `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -14,7 +14,7 @@ To begin using the checkout starter kit, ensure that your Adobe Commerce install
 
 You must install or have access to the following prerequisites to develop with the Adobe Commerce checkout starter kit:
 
-- Adobe Commerce version `2.4.4` or higher.
+- Adobe Commerce as a Cloud Service or Adobe Commerce version `2.4.4` or higher.
 
 - [Node.js](https://nodejs.org/) version 22. If you have Node Version Manager (`nvm`) installed, you can run the following command to install and use the required version:
 
@@ -28,6 +28,10 @@ You must install or have access to the following prerequisites to develop with t
   Builder license. If you do not have access to the Adobe Developer Console or App Builder, refer to [get access to App Builder](https://developer.adobe.com/app-builder/docs/overview/getting_access/#get-access-to-app-builder).
 
 ## Install Commerce modules
+
+<InlineAlert variant="info" slots="text"/>
+
+Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring their local environment](#initial-configuration) or [configuring events](./configure.md#configure-events).
 
 Before installing Commerce modules, ensure that you have the required credentials in `auth.json` with [access to the Adobe Commerce repository](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys).
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -70,7 +70,7 @@ You can also refer to the [Adobe I/O Events Webhook FAQ](https://developer.adobe
 
 The checkout starter kit supports the following payments use cases. For more information, refer to [Payment methods](./configure.md#create-payment-methods) and the [Payment API reference](./payment-reference.md).
 
-### Payment flow
+### Get order details with masked cart ID
 
 The following steps demonstrate the payment flow for getting order details from Adobe Commerce using the masked cart ID:
 
@@ -118,7 +118,9 @@ setPaymentMethodOnCart(
 
 With this information persisted, you can configure an [Adobe Commerce Webhook](../../webhooks/index.md) so that every time an order is placed, a synchronous call dispatches to the App Builder application implementing the payment method to validate the payment.
 
-To register a webhook, [modify the `webhooks.xml` file](../../webhooks/hooks.md) and create a new webhook with the following configuration:
+To register a webhook in Adobe Commerce on Cloud or on-premises, [modify the `webhooks.xml` file](../../webhooks/hooks.md) and create a new webhook with the following configuration.
+
+For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md#create-webhooks-from-the-admin).
 
 ```yaml
 Hook Settings
@@ -227,7 +229,9 @@ After the webhook is registered, every time a shopping cart is requested, a sync
 
 Refer to [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js) for an example of how to process the request and return the list of available shipping methods.
 
-To register a webhook, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
+To register a webhook in Adobe Commerce on Cloud or on-premises, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
+
+For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md#create-webhooks-from-the-admin).
 
 The following example demonstrates how to add a webhook to the `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` method:
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -118,7 +118,11 @@ setPaymentMethodOnCart(
 
 With this information persisted, you can configure an [Adobe Commerce Webhook](../../webhooks/index.md) so that every time an order is placed, a synchronous call dispatches to the App Builder application implementing the payment method to validate the payment.
 
+<Edition name="paas" />
+
 To register a webhook in Adobe Commerce on Cloud or on-premises, [modify the `webhooks.xml` file](../../webhooks/hooks.md) and create a new webhook with the following configuration.
+
+<Edition name="saas" />
 
 For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md).
 
@@ -229,9 +233,9 @@ After the webhook is registered, every time a shopping cart is requested, a sync
 
 Refer to [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js) for an example of how to process the request and return the list of available shipping methods.
 
-To register a webhook in Adobe Commerce on Cloud or on-premises, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
+&#8203;<Edition name="paas" />To register a webhook in Adobe Commerce on Cloud or on-premises, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
 
-For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md).
+&#8203;<Edition name="saas" />For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md).
 
 The following example demonstrates how to add a webhook to the `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` method:
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -66,9 +66,13 @@ the [AppBuilder Applications with Adobe I/O Events](https://developer.adobe.com/
 
 You can also refer to the [Adobe I/O Events Webhook FAQ](https://developer.adobe.com/events/docs/support/faq/#webhook-faq) which contains information about how to handle event consumption, such as state of registration, retries, and debugging.
 
-## Payment flow: Get order details from Adobe Commerce using the masked cart ID
+## Payment
 
-The following steps demonstrate the payment flow:
+The checkout starter kit supports the following payments use cases:
+
+### Payment flow
+
+The following steps demonstrate the payment flow for getting order details from Adobe Commerce using the masked cart ID:
 
 1. The payment flow starts at the frontend. When checkout is completed, the frontend sends the masked cart ID to the payment gateway.
 
@@ -78,7 +82,11 @@ The following steps demonstrate the payment flow:
 
 ![sequence.png](../../_images/starterkit/sequence.png)
 
-## Payment methods: Validate payment info
+### Payment methods
+
+The checkout starter kit supports the following payment methods use cases:
+
+#### Validate payment info
 
 To perform a headless checkout and payment, the Commerce instance must ensure that the payment has succeeded and the order can be placed.
 
@@ -138,7 +146,7 @@ You can also enable webhook signature generation by following the [webhooks sign
 
 Refer to [`actions/validate-payment.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/validate-payment/index.js) for an example of how to receive the request and validate the payment according to the payment gateway needs.
 
-## Payment methods: Filter out payment method
+#### Filter out payment method
 
 In some cases, you may want to filter out a payment method based on the cart details or the customer's information. For example, you may want to disable a payment method based on customer group or product attributes in the cart.
 
@@ -209,7 +217,11 @@ Payload example:
 
 You can find examples of how to filter out payment methods using customer data or product attributes in your App Builder application in [`actions/filter-payment.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/filter-payment/index.js).
 
-## Shipping methods
+## Shipping
+
+The checkout starter kit supports the following shipping use cases:
+
+### Shipping methods
 
 You can add shipping methods to the checkout process by using [webhooks](../../webhooks/index.md).
 
@@ -243,13 +255,7 @@ The following example demonstrates how to add a webhook to the `plugin.magento.o
 
 You can register multiple webhooks for different shipping methods or shipping carriers by adding them into the same batch to ensure they are executed in parallel or create multiple batches to execute them sequentially.
 
-### Remove shipping method
-
-The `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` webhook allows you to remove specific shipping methods from the list of available options.
-
-If you use the `flatrate` shipping method, but want to disable it, you must update your webhook response to mark the shipping method as removed. This example is demonstrated in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
-
-## Shipping methods: Payload
+#### Payload
 
 The request payload contains information about all items in the cart, including product information, product attributes, shipping address, and customer information for logged-in customers.
 
@@ -327,7 +333,7 @@ Payload example:
 
 You can find examples of how to use shipping addresses, customer data, and product attributes in your App Builder application in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
 
-## Shipping methods: GraphQL
+#### GraphQL
 
 In the `setShippingAddressesOnCart` mutation, available shipping methods that are returned by the webhook are appended to the `available_shipping_methods` field.
 
@@ -471,3 +477,9 @@ In the `setShippingMethodsOnCart` mutation, you can set the shipping method prov
   }
 }
 ```
+
+### Remove shipping method
+
+The `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` webhook allows you to remove specific shipping methods from the list of available options.
+
+If you use the `flatrate` shipping method, but want to disable it, you must update your webhook response to mark the shipping method as removed. This example is demonstrated in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -68,7 +68,7 @@ You can also refer to the [Adobe I/O Events Webhook FAQ](https://developer.adobe
 
 ## Payment
 
-The checkout starter kit supports the following payments use cases:
+The checkout starter kit supports the following payments use cases. For more information, refer to [Payment methods](./configure.md#create-payment-methods) and the [Payment API reference](./payment-reference.md).
 
 ### Payment flow
 
@@ -82,11 +82,7 @@ The following steps demonstrate the payment flow for getting order details from 
 
 ![sequence.png](../../_images/starterkit/sequence.png)
 
-### Payment methods
-
-The checkout starter kit supports the following payment methods use cases:
-
-#### Validate payment info
+### Validate payment info
 
 To perform a headless checkout and payment, the Commerce instance must ensure that the payment has succeeded and the order can be placed.
 
@@ -146,7 +142,7 @@ You can also enable webhook signature generation by following the [webhooks sign
 
 Refer to [`actions/validate-payment.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/validate-payment/index.js) for an example of how to receive the request and validate the payment according to the payment gateway needs.
 
-#### Filter out payment method
+### Filter out payment method
 
 In some cases, you may want to filter out a payment method based on the cart details or the customer's information. For example, you may want to disable a payment method based on customer group or product attributes in the cart.
 

--- a/src/pages/starter-kit/checkout/use-cases.md
+++ b/src/pages/starter-kit/checkout/use-cases.md
@@ -120,7 +120,7 @@ With this information persisted, you can configure an [Adobe Commerce Webhook](.
 
 To register a webhook in Adobe Commerce on Cloud or on-premises, [modify the `webhooks.xml` file](../../webhooks/hooks.md) and create a new webhook with the following configuration.
 
-For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md#create-webhooks-from-the-admin).
+For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md).
 
 ```yaml
 Hook Settings
@@ -231,7 +231,7 @@ Refer to [`actions/shipping-methods.js`](https://github.com/adobe/commerce-check
 
 To register a webhook in Adobe Commerce on Cloud or on-premises, you need to create a `webhooks.xml` [configuration file](../../webhooks/xml-schema.md) in your module or in the root `app/etc` directory.
 
-For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md#create-webhooks-from-the-admin).
+For Adobe Commerce as a Cloud Service, you can [create webhook in the Admin](../../webhooks/create-webhooks.md).
 
 The following example demonstrates how to add a webhook to the `plugin.magento.out_of_process_shipping_methods.api.shipping_rate_repository.get_rates` method:
 

--- a/src/pages/starter-kit/integration/create-integration.md
+++ b/src/pages/starter-kit/integration/create-integration.md
@@ -204,17 +204,17 @@ Use the following steps to download and configure the Adobe Commerce integration
 
 When configuring the `COMMERCE_BASE_URL` environment variable, the format differs between [PaaS and SaaS](#paas-or-saas):
 
-&#8203;<Edition name="paas" />For PaaS (On-Premise/Cloud):
+* &#8203;<Edition name="paas" />For PaaS (On-Premise/Cloud):
 
    * `COMMERCE_BASE_URL` must include your base site URL + `/rest/`
    * Example: `https://<environment-name>.us-4.magentosite.cloud/rest/`
 
-&#8203;<Edition name="saas" />For SaaS (Adobe Commerce as a Cloud Service):
+* &#8203;<Edition name="saas" />For SaaS (Adobe Commerce as a Cloud Service):
 
    * `COMMERCE_BASE_URL` must be the REST API endpoint provided by Adobe Commerce
    * Example: `https://na1-sandbox.api.commerce.adobe.com/<tenant-id>/`
 
-   Make sure to use your actual environment name or tenant ID in the URL. The examples above use placeholder values.
+Make sure to use your actual environment name or tenant ID in the URL. The examples above use placeholder values.
 
 #### Configure the starter kit
 

--- a/src/pages/starter-kit/integration/create-integration.md
+++ b/src/pages/starter-kit/integration/create-integration.md
@@ -97,15 +97,17 @@ To download a `.json` file containing your workspace configuration:
 
 The integration starter kit is designed to work with all Adobe Commerce versions, but only one at a time. This means that you can use either Adobe Commerce on Cloud / on Premises (PaaS) or Adobe Commerce as a Cloud Service (SaaS). By default, the starter kit will check for PaaS authentication first using **OAuth1**, before it checks for SaaS authentication using **IMS**.
 
-* For PaaS configurations, refer to [Create an integration in Adobe Commerce (PaaS only)](#create-an-integration-in-adobe-commerce-paas-only) and make sure your environment variables `COMMERCE_XXXX` are set correctly in the `.env` file.
+&#8203;<Edition name="paas" /> For PaaS configurations, refer to [Create an integration in Adobe Commerce (PaaS only)](#create-an-integration-in-adobe-commerce-paas-only) and make sure your environment variables `COMMERCE_XXXX` are set correctly in the `.env` file.
 
-* For SaaS configurations, refer to [Create an integration in Adobe Commerce as a Cloud Service](#create-an-integration-in-adobe-commerce-as-a-cloud-service) and make sure the environment variables file does not contain `COMMERCE_XXXX` variables.
+&#8203;<Edition name="saas" /> For SaaS configurations, refer to [Create an integration in Adobe Commerce as a Cloud Service](#create-an-integration-in-adobe-commerce-as-a-cloud-service) and make sure the environment variables file does not contain `COMMERCE_XXXX` variables.
 
 <InlineAlert variant="info" slots="text"/>
 
 `app.config.yaml` has both sets of environment variables declared. These determine the runtime action context. This file works regardless of offering, so you do not need to modify it.
 
 #### Create an integration in Adobe Commerce (PaaS only)
+
+<Edition name="paas" />
 
 A Commerce integration generates the consumer key, consumer secret, access token, and access token secret that are required to connect to the starter kit. It also identifies the available API resources that are needed for the integration.
 
@@ -138,6 +140,8 @@ Use the following steps to create and activate an integration.
    You will need the integration details (consumer key, consumer secret, access token, and access token secret) to configure the starter kit. Copy these values to a safe place and click **Done**.
 
 #### Create an integration in Adobe Commerce as a Cloud Service
+
+<Edition name="saas" />
 
 To configure authentication for Adobe Commerce as a Cloud Service (SaaS), you need to add OAuth server-to-server credentials to your environment.
 
@@ -200,12 +204,12 @@ Use the following steps to download and configure the Adobe Commerce integration
 
 When configuring the `COMMERCE_BASE_URL` environment variable, the format differs between [PaaS and SaaS](#paas-or-saas):
 
-   For PaaS (On-Premise/Cloud):
+&#8203;<Edition name="paas" />For PaaS (On-Premise/Cloud):
 
    * `COMMERCE_BASE_URL` must include your base site URL + `/rest/`
    * Example: `https://<environment-name>.us-4.magentosite.cloud/rest/`
 
-   For SaaS (Adobe Commerce as a Cloud Service):
+&#8203;<Edition name="saas" />For SaaS (Adobe Commerce as a Cloud Service):
 
    * `COMMERCE_BASE_URL` must be the REST API endpoint provided by Adobe Commerce
    * Example: `https://na1-sandbox.api.commerce.adobe.com/<tenant-id>/`


### PR DESCRIPTION
This PR adds badging for the starter kits based on the strategy added by #352.

It appears that having the tags at the beginning a line causes the parser to interpret everything else in the line as `html` and not `markdown`. I attempted to shadow the parser and modify it to resolve the issue, but I was unsuccessful. My simple, but inelegant, solution is to add a no-width space character (`&#8203;`) to the beginning of the line. I also tried incorporating this character into the shadowed component, but that did not modify the offending parser behavior.

