### PR TITLE
CEXT-4580: Release commerce eventing 1.12.1

### DIFF
--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -132,7 +132,7 @@ The `GET /rest/all/V1/eventing/getEventSubscriptions` endpoint returns a list of
   "destination": "default",
   "priority": false,
   "hipaa_audit_required": false,
-  "provider_id": "default"
+  "provider_id": "1902bc50-12345-41e8-955b-af4a9667823f"
 }]
 ```
 
@@ -390,6 +390,8 @@ curl -i -X PUT \
 ### Delete event provider
 
 The `DELETE /rest/<store_view_code>/V1/eventing/eventProvider/<provider_id>` endpoint deletes the event provider with the specified ID from the Adobe Commerce instance. The event provider is not removed from the Adobe Developer Console.
+
+To delete an event provider, you must first delete all event subscriptions that use this provider. The event provider cannot be deleted if used in event subscriptions.
 
 **Headers:**
 

--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -391,7 +391,7 @@ curl -i -X PUT \
 
 The `DELETE /rest/<store_view_code>/V1/eventing/eventProvider/<provider_id>` endpoint deletes the event provider with the specified ID from the Adobe Commerce instance. The event provider is not removed from the Adobe Developer Console.
 
-To delete an event provider, you must first delete all event subscriptions that use this provider. The event provider cannot be deleted if used in event subscriptions.
+To delete an event provider, you must first delete all event subscriptions that use this provider. An event provider cannot be deleted if it is used in any event subscriptions.
 
 **Headers:**
 

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,21 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.12.1
+
+### Release date
+
+April 29, 2025
+
+### Enhancements
+
+* Returns the provider ID instead of "default" in the REST API. <!-- CEXT-4561 -->
+
+* Improves the message during the removal of providers with linked event subscriptions. <!-- CEXT-4577 -->
+
+* Allows the removal of event providers with inactive subscriptions. <!-- CEXT-4583 -->
+
+
 ## Version 1.12.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for commerce eventing 1.12.1 release

https://jira.corp.adobe.com/browse/CEXT-4580

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/release-notes/
- https://developer.adobe.com/commerce/extensibility/events/api/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
