### PR TITLE
CEXT-4542: Starterkit multi event provider doc update

### DIFF
--- a/src/pages/starter-kit/integration/create-integration.md
+++ b/src/pages/starter-kit/integration/create-integration.md
@@ -175,7 +175,7 @@ If you are running Adobe Commerce 2.4.6 or higher, the modules that enable event
 
 <InlineAlert variant="info" slots="text"/>
 
-Using Adobe I/O Events for Commerce `1.6.0` or later will automate some steps of the onboarding process detailed in the following section.
+Using Adobe I/O Events for Commerce `1.12.0` or later will automate some steps of the onboarding process detailed in the following section.
 
 ### Download and configure the starter kit
 
@@ -278,7 +278,7 @@ The Customize Registrations and Events [code sample](https://github.com/adobe/ad
 
 Run the following command to generate the IO Event providers and the registrations for your starter kit project.
 
-IO Event providers and registrations will be configured automatically if you are using Adobe I/O Events version is `1.6.0` or later.
+IO Event providers and registrations will be configured automatically and your commerce instance can connect to other event providers besides the default Commerce event provider registered in the system configuration if you are using Adobe I/O Events version `1.12.0` or later.
 
 ```bash
 npm run onboard
@@ -311,7 +311,7 @@ Check your App in the Developer Console to confirm the registrations were create
 
 <InlineAlert variant="info" slots="text"/>
 
-The following steps are not required when using Adobe I/O Events version `1.6.0` or later. The onboarding script will configure the Adobe Commerce instance automatically.
+The following steps are not required when using Adobe I/O Events version `1.12.0` or later. The onboarding script will configure the Adobe Commerce instance automatically.
 
 Proceed to the next section, or continue following the steps in this section to validate that the configuration is correct.
 
@@ -353,7 +353,7 @@ You must configure Commerce to communicate with your project. Configuration incl
 
 **Subscribe to events in Adobe Commerce**
 
-To automatically subscribe to Commerce events using Adobe I/O Events version `1.6.0` or later, run the `commerce-event-subscribe` script in the `scripts/commerce-event-subscribe/config/` directory.
+To automatically subscribe to Commerce events using Adobe I/O Events version `1.12.0` or later, run the `commerce-event-subscribe` script in the `scripts/commerce-event-subscribe/config/` directory.
 
 ```bash
 npm run commerce-event-subscribe


### PR DESCRIPTION
## Purpose of this pull request

This PR adds multi event provider update to the integration starter kit.
[CEXT-4542](https://jira.corp.adobe.com/browse/CEXT-4542)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- [create-integration.md](https://github.com/AdobeDocs/commerce-extensibility/blob/main/src/pages/starter-kit/integration/create-integration.md)

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
