### PR TITLE
CEXT-4672: document update behaviour of `POST /V1/oope_payment_method`

### DIFF
--- a/src/pages/starter-kit/checkout/payment-reference.md
+++ b/src/pages/starter-kit/checkout/payment-reference.md
@@ -23,9 +23,11 @@ The raw Payment REST API schema is available [here](/payment.xml).
 | `/V1/oope_payment_method/:code` | GET        | Retrieve an out-of-process payment method by its code. |
 | `/V1/oope_payment_method`       | GET        | List all available out-of-process payment methods.     |
 
-### Create a new payment method
+### Create or update a payment method
 
-The POST `/V1/oope_payment_method/` creates an out-of-process payment method in the Adobe Commerce instance.
+The POST `/V1/oope_payment_method/` creates or updates an out-of-process payment method in the Adobe Commerce instance.
+The `code` parameter is used to identify the payment method. If a payment method with the same `code` already exists,
+it will be updated; otherwise, a new payment method will be created.
 
 **Payload parameters:**
 

--- a/src/pages/starter-kit/checkout/payment-usage.md
+++ b/src/pages/starter-kit/checkout/payment-usage.md
@@ -19,7 +19,7 @@ const commerceClient = await getAdobeCommerceClient(process.env);
 
 `createOopePaymentMethod` creates a new out-of-process payment method with the necessary details such as `code`, `title`, and `configuration`.
 
-Check the [API reference](./payment-reference.md#create-a-new-payment-method) for more details.
+Check the [API reference](./payment-reference.md#create-or-update-a-payment-method) for more details.
 
 <CodeBlock slots="heading, code" repeat="1" languages="javascript" />
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
