### PR TITLE
CEXT-4676: Update the documentation with webhook context section

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -265,17 +265,175 @@ You can also specify the string arguments to use when accessing the application 
 </fields>
 ```
 
+The object return is not supported for the context fields. The return value must be a scalar value or an array. For example, if you want to get the value of `Magento\Checkout\Model\Session::getQuote()::getSubtotal()`, you can use the following configuration:
+
+```xml
+<fields>
+    <field name="quote.subtotal" source="context_checkout_session.get_quote.get_sub_total" />
+</fields>
+```
+
 Supported contexts:
 
 | Context                     | Context class                                     |
 |-----------------------------|---------------------------------------------------|
 | `context_checkout_session`  | Magento\Checkout\Model\Session                    |
 | `context_customer_session`  | Magento\Customer\Model\Session                    |
-| `context_registry`          | Magento\Framework\Registry                        |
 | `context_application_state` | Magento\Framework\App\State                       |
 | `context_scope_config`      | Magento\Framework\App\Config\ScopeConfigInterface |
 | `context_http_request`      | Magento\Framework\App\Request\Http                |
 | `context_staging`           | Magento\Staging\Model\VersionManager              |
+
+
+#### Checkout session context
+
+The `context_checkout_session` context is used to retrieve information about the current checkout session. You can use this context to access the information about the current quote.
+
+```xml
+<fields>
+    <field name="quote.id" source="context_checkout_session.get_quote.get_id" />
+    <field name="quote.sub_total" source="context_checkout_session.get_quote.get_subtotal" />
+    <field name="quote.customer_group_id" source="context_checkout_session.get_quote.get_customer_group_id" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "quote": {
+        "id": "66",
+        "sub_total": "600.0000",
+        "customer_group_id": "0"
+    }
+}
+```
+
+If the quote does not exist in the current session the values will be set to `null`.
+
+#### Customer session context
+
+The `context_customer_session` context is used to retrieve information about the current customer session. You can use this context to access the information about the current customer.
+
+```xml
+<fields>
+    <field name="customer.id" source="context_customer_session.get_customer.get_id" />
+    <field name="customer.email" source="context_customer_session.get_customer.get_email" />
+    <field name="customer.group_id" source="context_customer_session.get_customer.get_group_id" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "customer": {
+        "id": "123",
+        "email": "test@example.com",
+        "group_id": "2"
+    }
+}
+```
+
+If the customer is not logged in, the values will be set to `null`.
+
+#### Application state context
+
+The `context_application_state` context is used to retrieve information about the current application state.
+
+```xml
+<fields>
+    <field name="app_area_code" source="context_application_state.get_area_code" />
+    <field name="app_mode" source="context_application_state.get_mode" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "app_area_code": "webapi_rest",
+    "app_mode": "production"
+}
+```
+
+The `context_application_state.get_area_code` field returns the area code of the application where webhook execution occurs. The possible values are `global`, `frontend`, `adminhtml`, `crontab`, `webapi_rest`, `webapi_soap`, `graphql`. This value can be used to determine the context of the request and to apply specific logic based on the area code.
+
+The `context_application_state.get_mode` field returns the current application mode. The possible values are `default`, `developer`, and `production`.
+
+#### Scope config context
+
+The `context_scope_config` context is used to retrieve information from the configuration scope. If your webhook logic depends on a specific configuration value, you can use this context to retrieve the value from the configuration.
+
+The following example retrieves the `general/locale/timezone` and `general/locale/code` configuration values from the default scope.
+
+```xml
+<fields>
+    <field name="config.timezone" source="context_scope_config.get_value{general/locale/timezone:default}" />
+    <field name="config.local" source="context_scope_config.get_value{general/locale/code:default}" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "config": {
+        "timezone": "America/Chicago",
+        "local": "en_US"
+    }
+}
+```
+
+#### HTTP request context
+
+The `context_http_request` context is used to retrieve information about the current HTTP request.
+
+```xml
+<fields>
+    <field name="request.path_info" source="context_http_request.get_path_info" />
+    <field name="request.base_path" source="context_http_request.get_base_path" />
+    <field name="request.front_name" source="context_http_request.get_front_name" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "request": {
+        "path_info": "/rest/default/V1/guest-carts/estimate-shipping-methods",
+        "base_path": "/",
+        "front_name": "rest"
+    }
+}
+```
+
+#### Staging context
+
+The `context_staging` context is used to retrieve information about the current staging version.
+
+```xml
+<fields>
+    <field name="staging.version" source="context_staging.get_version" />
+    <field name="staging.current_version" source="context_staging.get_current_version" />
+</fields>
+```
+
+The example above will send the following JSON object to the webhook endpoint:
+
+```json
+{
+    "staging": {
+        "version": {
+            "id": 1
+        },
+        "current_version": {
+            "id": 1
+        }
+    }
+}
+```
 
 ## Clean the cache
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -126,6 +126,10 @@ To transmit this object to the remote application, you will need to remove the `
 
 The following example configures the webhook described above.
 
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
+
 ```xml
 <hook name="validate_stock" url="https://example.com/product-validate-stock" timeout="2000" softTimeout="200" required="true" fallbackErrorMessage="Can't add the product to the cart right now">
     <fields>
@@ -134,6 +138,24 @@ The following example configures the webhook described above.
         <field name='product.quantity' source='data.product.qty' />
     </fields>
 </hook>
+```
+
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: product.name
+Source: data.product.name
+Active: Yes
+
+Name: product.sku
+Source: data.product.sku
+Active: Yes
+
+Name: product.quantity
+Source: data.product.qty
+Active: Yes
 ```
 
 If the default payload of a webhook contains an array of objects, use the following construction to select fields from that array:
@@ -194,6 +216,10 @@ For example, the payload of the `plugin.magento.quote.api.shipment_estimation.es
 
 To transmit the `postcode` property of the `address` object and the `carrier_code`, `method_code`, and `base_amount` for each shipping estimate, configure the webhook's fields as follows:
 
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
+
 ```xml
 <fields>
     <field name='postcode' source='address.postcode' />
@@ -201,6 +227,28 @@ To transmit the `postcode` property of the `address` object and the `carrier_cod
     <field name='result[].method_code' />
     <field name='result[].base_amount' />
 </fields>
+```
+
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: postcode
+Source: address.postcode
+Active: Yes
+
+Name: result[].carrier_code
+Source: result[].carrier_code
+Active: Yes
+
+Name: result[].method_code
+Source: result[].method_code
+Active: Yes
+
+Name: result[].base_amount
+Source: result[].base_amount
+Active: Yes
 ```
 
 Commerce sends the following object to the remote application:
@@ -248,6 +296,10 @@ For example, given the above hook field configuration, conversion occurs only if
 
 You can add to the webhook payload values from the application context:
 
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
+
 ```xml
 <fields>
     <field name="customer.entity_id" source="data.customer.entity_id" />
@@ -255,9 +307,27 @@ You can add to the webhook payload values from the application context:
 </fields>
 ```
 
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: customer.entity_id
+Source: data.customer.entity_id
+Active: Yes
+
+Name: customer.customer_email
+Source: context_customer_session.get_customer.get_email
+Active: Yes
+```
+
 In this example, the value of `customer.customer_email` will be set to `Magento\Customer\Model\Session::getCustomer()::getEmail()`. If the value does not exist or cannot be processed, the appropriate message will be logged, and the hook execution will not be interrupted.
 
 You can also specify the string arguments to use when accessing the application context. Provide these arguments within curly braces and delimit multiple arguments with colons, if applicable. The following example sets `config_value` to the value of `Magento\Framework\App\Config\ScopeConfigInterface::getValue('value/path', 'default')`.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -265,12 +335,37 @@ You can also specify the string arguments to use when accessing the application 
 </fields>
 ```
 
-The object return is not supported for the context fields. The return value must be a scalar value or an array. For example, if you want to get the value of `Magento\Checkout\Model\Session::getQuote()::getSubtotal()`, you can use the following configuration:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: config_value
+Source: context_scope_config.get_value{value/path:default}
+Active: Yes
+```
+
+In this example, the value of `config_value` will be set to the value of `Magento\Framework\App\Config\ScopeConfigInterface::getValue('value/path', 'default')`. If the value does not exist or cannot be processed, the appropriate message will be logged, and the hook execution will not be interrupted.
+
+The return value must be a scalar value or an array. Context fields do not support returned objects.  For example, if you want to get the value of `Magento\Checkout\Model\Session::getQuote()::getSubtotal()`, you can use the following configuration:
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
     <field name="quote.subtotal" source="context_checkout_session.get_quote.get_sub_total" />
 </fields>
+```
+
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+Name: quote.subtotal
+Source: context_checkout_session.get_quote.get_sub_total
+Active: Yes
 ```
 
 Supported contexts:
@@ -284,10 +379,13 @@ Supported contexts:
 | `context_http_request`      | Magento\Framework\App\Request\Http                |
 | `context_staging`           | Magento\Staging\Model\VersionManager              |
 
-
 #### Checkout session context
 
-The `context_checkout_session` context is used to retrieve information about the current checkout session. You can use this context to access the information about the current quote.
+The `context_checkout_session` context retrieves information about the current checkout session. You can use this context to access the information about the current quote.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -297,7 +395,25 @@ The `context_checkout_session` context is used to retrieve information about the
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: quote.id
+Source: context_checkout_session.get_quote.get_id
+Active: Yes
+
+Name: quote.sub_total
+Source: context_checkout_session.get_quote.get_subtotal
+Active: Yes
+
+Name: quote.customer_group_id
+Source: context_checkout_session.get_quote.get_customer_group_id
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -309,11 +425,15 @@ The example above will send the following JSON object to the webhook endpoint:
 }
 ```
 
-If the quote does not exist in the current session the values will be set to `null`.
+If the quote does not exist in the current session, the values will be set to `null`.
 
 #### Customer session context
 
-The `context_customer_session` context is used to retrieve information about the current customer session. You can use this context to access the information about the current customer.
+The `context_customer_session` retrieves information about the current customer session. You can use this context to access the information about the current customer.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -323,7 +443,25 @@ The `context_customer_session` context is used to retrieve information about the
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: customer.id
+Source: context_customer_session.get_customer.get_id
+Active: Yes
+
+Name: customer.email
+Source: context_customer_session.get_customer.get_email
+Active: Yes
+
+Name: customer.group_id
+Source: context_customer_session.get_customer.get_group_id
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -339,7 +477,11 @@ If the customer is not logged in, the values will be set to `null`.
 
 #### Application state context
 
-The `context_application_state` context is used to retrieve information about the current application state.
+The `context_application_state` context retrieves information about the current application state.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -348,7 +490,19 @@ The `context_application_state` context is used to retrieve information about th
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+Name: app_area_code
+Source: context_application_state.get_area_code
+Active: Yes
+Name: app_mode
+Source: context_application_state.get_mode
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -363,9 +517,13 @@ The `context_application_state.get_mode` field returns the current application m
 
 #### Scope config context
 
-The `context_scope_config` context is used to retrieve information from the configuration scope. If your webhook logic depends on a specific configuration value, you can use this context to retrieve the value from the configuration.
+The `context_scope_config` context retrieves information from the configuration scope. If your webhook logic depends on a specific configuration value, you can use this context to retrieve the value from the configuration.
 
 The following example retrieves the `general/locale/timezone` and `general/locale/code` configuration values from the default scope.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -374,7 +532,21 @@ The following example retrieves the `general/locale/timezone` and `general/local
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: config.timezone
+Source: context_scope_config.get_value{general/locale/timezone:default}
+Active: Yes
+
+Name: config.local
+Source: context_scope_config.get_value{general/locale/code:default}
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -387,7 +559,11 @@ The example above will send the following JSON object to the webhook endpoint:
 
 #### HTTP request context
 
-The `context_http_request` context is used to retrieve information about the current HTTP request.
+The `context_http_request` context retrieves information about the current HTTP request.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -397,7 +573,25 @@ The `context_http_request` context is used to retrieve information about the cur
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+
+Name: request.path_info
+Source: context_http_request.get_path_info
+Active: Yes
+
+Name: request.base_path
+Source: context_http_request.get_base_path
+Active: Yes
+
+Name: request.front_name
+Source: context_http_request.get_front_name
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -411,7 +605,11 @@ The example above will send the following JSON object to the webhook endpoint:
 
 #### Staging context
 
-The `context_staging` context is used to retrieve information about the current staging version.
+The `context_staging` context retrieves information about the current staging version.
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
 
 ```xml
 <fields>
@@ -420,7 +618,19 @@ The `context_staging` context is used to retrieve information about the current 
 </fields>
 ```
 
-The example above will send the following JSON object to the webhook endpoint:
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+Name: staging.version
+Source: context_staging.get_version
+Active: Yes
+Name: staging.current_version
+Source: context_staging.get_current_version
+Active: Yes
+```
+
+This hook sends the following JSON object to the webhook endpoint:
 
 ```json
 {
@@ -436,6 +646,8 @@ The example above will send the following JSON object to the webhook endpoint:
 ```
 
 ## Clean the cache
+
+<Edition name="paas" />
 
 If you are adding webhook functionality to an instance that is in production mode, run the following command to clean the cache and make the webhook available to the system:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds examples of how to use contexts to retrieve additional data for the webhook payload.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/hooks/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
