### PR TITLE
CEXT-4693: Extend the shipping methods webhook payload with the selected method

### DIFF
--- a/src/pages/starter-kit/checkout/shipping-use-cases.md
+++ b/src/pages/starter-kit/checkout/shipping-use-cases.md
@@ -117,10 +117,16 @@ Payload example:
             "middlename": null,
             "lastname": "Doe",
             ...
+        },
+        "selected_shipping_method": {
+            "carrier_code": "DPS",
+            "method_code": "dps_shipping_one"
         }
     }
 }
 ```
+
+The request payload also contains information about the selected shipping method if it was already selected before webhook execution. In case the shipping method is not selected yet, the `selected_shipping_method` field is `null`.
 
 You can find examples of how to use shipping addresses, customer data, and product attributes in your App Builder application in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
 

--- a/src/pages/starter-kit/checkout/shipping-use-cases.md
+++ b/src/pages/starter-kit/checkout/shipping-use-cases.md
@@ -126,7 +126,7 @@ Payload example:
 }
 ```
 
-The request payload also contains information about the selected shipping method if it was already selected before webhook execution. In case the shipping method is not selected yet, the `selected_shipping_method` field is `null`.
+The request payload also contains information about the selected shipping method, if it was already selected before webhook execution. When no shipping method has been selected yet, the `selected_shipping_method` field is `null`.
 
 You can find examples of how to use shipping addresses, customer data, and product attributes in your App Builder application in [`actions/shipping-methods.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/actions/shipping-methods/index.js).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds an example of the selected shipping methods in the webhook payload

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/shipping-use-cases/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
