### PR TITLE
CEXT-4724: Update the minimum Commerce version of Tax to v2.4.6

### DIFF
--- a/src/_includes/checkout-version.md
+++ b/src/_includes/checkout-version.md
@@ -1,6 +1,6 @@
 <InlineAlert variant="info" slots="text"/>
 
-Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring their local environment](#initial-configuration) or [configuring Commerce](./configure.md).
+Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring App Builder project](./getting-started.md#initial-configuration) or [configuring Commerce](./configure.md).
 
 <Edition name="paas" />
 

--- a/src/_includes/checkout-version.md
+++ b/src/_includes/checkout-version.md
@@ -1,6 +1,6 @@
 <InlineAlert variant="info" slots="text"/>
 
-Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring App Builder project](./getting-started.md#initial-configuration) or [configuring Commerce](./configure.md).
+Adobe Commerce as a Cloud Service is preconfigured with all the required modules for the checkout starter kit. Cloud Service users can proceed by [configuring an App Builder project](./getting-started.md#initial-configuration) or [configuring Commerce](./configure.md).
 
 <Edition name="paas" />
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -48,7 +48,7 @@ An App Builder project must be created before using the checkout starter kit.
 1. Log in to the [Adobe Developer Console](https://console.adobe.io/) and select the desired organization from the dropdown menu in the top-right corner.
 
 1. Click **Create new project from template**.
-  **NOTE**: If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
+    * If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
 
 1. Select **App Builder**. The **Set up templated project** page displays.
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -48,7 +48,7 @@ An App Builder project must be created before using the checkout starter kit.
 1. Log in to the [Adobe Developer Console](https://console.adobe.io/) and select the desired organization from the dropdown menu in the top-right corner.
 
 1. Click **Create new project from template**.
-    * If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
+   1. If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
 
 1. Select **App Builder**. The **Set up templated project** page displays.
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -48,7 +48,8 @@ An App Builder project must be created before using the checkout starter kit.
 1. Log in to the [Adobe Developer Console](https://console.adobe.io/) and select the desired organization from the dropdown menu in the top-right corner.
 
 1. Click **Create new project from template**.
-   1. If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
+
+  **NOTE**: If the **Create project from template** option is not displayed, your request to access App Builder might not yet be approved.
 
 1. Select **App Builder**. The **Set up templated project** page displays.
 
@@ -62,11 +63,11 @@ Use the following steps to configure your local environment:
 
 1. Execute the following command to create an Adobe Developer Console project in your organization and using the Commerce checkout starter kit as a template:
 
-```bash
-aio app init --repo adobe/commerce-checkout-starter-kit --github-pat $GITHUB_PAT
-```
-
-Replace `$GITHUB_PAT` with your GitHub personal access token. For more information, refer to [managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+  ```bash
+  aio app init --repo adobe/commerce-checkout-starter-kit --github-pat $GITHUB_PAT
+  ```
+  
+  Replace `$GITHUB_PAT` with your GitHub personal access token. For more information, refer to [managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 1. The starter kit requires you to add the following services in the console project:
 
@@ -74,11 +75,11 @@ Replace `$GITHUB_PAT` with your GitHub personal access token. For more informati
    - I/O Events
    - Adobe I/O Events for Adobe Commerce
 
-Execute the following command to add the services by selecting them from the list:
-
-```bash
-aio app add service
-```
+  Execute the following command to add the services by selecting them from the list:
+  
+  ```bash
+  aio app add service
+  ```
 
 1. Copy the environment variables from the [`env.dist`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/env.dist) to a local `.env` file and enter the required values.
 

--- a/src/pages/starter-kit/checkout/payment-install.md
+++ b/src/pages/starter-kit/checkout/payment-install.md
@@ -14,6 +14,12 @@ To begin using the payment module with the checkout starter kit, ensure that you
 
 For more ideas on how you can use the payment module, refer to [payment use cases](./payment-use-cases.md).
 
+## Prerequisites
+
+* Adobe Commerce on cloud infrastructure or on premises: 2.4.5+
+* PHP 8.1+
+* Magento Open Source is not supported.
+
 ## Installation
 
 <Version />

--- a/src/pages/starter-kit/checkout/payment-install.md
+++ b/src/pages/starter-kit/checkout/payment-install.md
@@ -16,7 +16,7 @@ For more ideas on how you can use the payment module, refer to [payment use case
 
 ## Prerequisites
 
-* Adobe Commerce on cloud infrastructure or on premises: 2.4.5+
+* Adobe Commerce on cloud infrastructure or on-premises: 2.4.5+
 * PHP 8.1+
 * Magento Open Source is not supported.
 

--- a/src/pages/starter-kit/checkout/shipping-install.md
+++ b/src/pages/starter-kit/checkout/shipping-install.md
@@ -17,7 +17,7 @@ For more ideas on how you can use the shipping module, refer to [shipping use ca
 ## Prerequisites
 
 * Adobe Commerce on cloud infrastructure or on premises: 2.4.5+
-* PHP 8.1+
+* PHP 8.2+
 * Magento Open Source is not supported.
 
 ## Installation

--- a/src/pages/starter-kit/checkout/shipping-install.md
+++ b/src/pages/starter-kit/checkout/shipping-install.md
@@ -14,6 +14,12 @@ To begin using the shipping module with the checkout starter kit, ensure that yo
 
 For more ideas on how you can use the shipping module, refer to [shipping use cases](./shipping-use-cases.md).
 
+## Prerequisites
+
+* Adobe Commerce on cloud infrastructure or on premises: 2.4.5+
+* PHP 8.1+
+* Magento Open Source is not supported.
+
 ## Installation
 
 <Version />

--- a/src/pages/starter-kit/checkout/shipping-install.md
+++ b/src/pages/starter-kit/checkout/shipping-install.md
@@ -16,7 +16,7 @@ For more ideas on how you can use the shipping module, refer to [shipping use ca
 
 ## Prerequisites
 
-* Adobe Commerce on cloud infrastructure or on premises: 2.4.5+
+* Adobe Commerce on cloud infrastructure or on-premises: 2.4.5+
 * PHP 8.2+
 * Magento Open Source is not supported.
 

--- a/src/pages/starter-kit/checkout/tax-install.md
+++ b/src/pages/starter-kit/checkout/tax-install.md
@@ -14,6 +14,12 @@ To begin using the checkout starter kit, ensure that you have completed the [get
 
 For more ideas on how you can use the tax module, refer to [tax use cases](./tax-use-cases.md).
 
+## Prerequisites
+
+* Adobe Commerce on cloud infrastructure or on premises: 2.4.6+
+* PHP 8.2+
+* Magento Open Source is not supported.
+
 ## Installation
 
 <Version />
@@ -22,6 +28,16 @@ To enable out-of-process tax management in Adobe Commerce, install the `magento/
 
 ```bash
  composer require magento/module-out-of-process-tax-management --with-dependencies
+```
+
+## Configuration
+
+The starter kit provides the [`create-tax-integrations`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-tax-integrations.js) script to help configure Adobe Commerce. It reads the tax integrations configuration from the `tax-integrations.yaml` file and creates tax integrations in Adobe Commerce.
+
+To run this script, use the following command:
+
+```bash
+npm run create-tax-integrations
 ```
 
 ## Limitations
@@ -36,13 +52,3 @@ This extension overrides the class `Magento\Tax\Model\Sales\Total\Quote\Tax` in 
 As a result, this extension is not compatible with other tax extensions that also override this class, such as TaxJar or Avalara.
 
 If you need to use another tax extension, Adobe recommends disabling this extension to prevent conflicts.
-
-## Configuration
-
-The starter kit provides the [`create-tax-integrations`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-tax-integrations.js) script to help configure Adobe Commerce. It reads the tax integrations configuration from the `tax-integrations.yaml` file and creates tax integrations in Adobe Commerce.
-
-To run this script, use the following command:
-
-```bash
-npm run create-tax-integrations
-```

--- a/src/pages/starter-kit/checkout/tax-install.md
+++ b/src/pages/starter-kit/checkout/tax-install.md
@@ -16,7 +16,7 @@ For more ideas on how you can use the tax module, refer to [tax use cases](./tax
 
 ## Prerequisites
 
-* Adobe Commerce on cloud infrastructure or on premises: 2.4.6+
+* Adobe Commerce on cloud infrastructure or on-premises: 2.4.6+
 * PHP 8.2+
 * Magento Open Source is not supported.
 

--- a/src/pages/starter-kit/checkout/tax-install.md
+++ b/src/pages/starter-kit/checkout/tax-install.md
@@ -32,7 +32,7 @@ To enable out-of-process tax management in Adobe Commerce, install the `magento/
 
 ## Configuration
 
-The starter kit provides the [`create-tax-integrations`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-tax-integrations.js) script to help configure Adobe Commerce. It reads the tax integrations configuration from the `tax-integrations.yaml` file and creates tax integrations in Adobe Commerce.
+The checkout starter kit provides the [`create-tax-integrations`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/scripts/create-tax-integrations.js) script to help configure Adobe Commerce. It reads the tax integrations configuration from the `tax-integrations.yaml` file and creates tax integrations in Adobe Commerce.
 
 To run this script, use the following command:
 


### PR DESCRIPTION
## Purpose of this pull request

- Update the minimum Commerce version of Tax to v2.4.6
- While evaluating the effort to support v2.4.5 for taxes, declare the minimum Commerce/PHP versions for each OOPE module explicitly.

@jhadobe Please feel free to update this PR as you prefer. Thanks!

## Related tickets

https://jira.corp.adobe.com/browse/CEXT-4724