### PR TITLE
CEXT-4431: Add supported webhooks and events endpoint info

### DIFF
--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -502,7 +502,7 @@ The `GET /V1/eventing/supportedList` endpoint returns the events supported in Ad
 ]
 ```
 
-The access token used in the request must have access to the Event List resource. See [REST authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for information on authentication for SaaS.
+The access token used in the request must have access to the `Eventing Framework > Event List` resource. See [REST authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for information on authentication for SaaS.
 
 **Example usage:**
 

--- a/src/pages/webhooks/api.md
+++ b/src/pages/webhooks/api.md
@@ -90,7 +90,7 @@ The `GET /V1/webhooks/supportedList` endpoint returns the events supported in Ad
 ]
 ```
 
-The access token used in the request must have access to the Webhooks List resource. See [REST authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for information on authentication for SaaS.
+The access token used in the request must have access to the `Webhooks > Webhooks Management > Webhooks List` resource. See [REST authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for information on authentication for SaaS.
 
 **Example usage:**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds documentation for the SaaS-specific supported webhooks and supported events REST endpoints.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/api/
- https://developer.adobe.com/commerce/extensibility/webhooks/api/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
