### PR TITLE
CEXT-4724: Support Adobe Commerce 2.4.5 in out-of-process tax management

### DIFF
--- a/src/pages/starter-kit/checkout/shipping-install.md
+++ b/src/pages/starter-kit/checkout/shipping-install.md
@@ -17,7 +17,7 @@ For more ideas on how you can use the shipping module, refer to [shipping use ca
 ## Prerequisites
 
 * Adobe Commerce on cloud infrastructure or on-premises: 2.4.5+
-* PHP 8.2+
+* PHP 8.1+
 * Magento Open Source is not supported.
 
 ## Installation

--- a/src/pages/starter-kit/checkout/tax-install.md
+++ b/src/pages/starter-kit/checkout/tax-install.md
@@ -16,8 +16,8 @@ For more ideas on how you can use the tax module, refer to [tax use cases](./tax
 
 ## Prerequisites
 
-* Adobe Commerce on cloud infrastructure or on-premises: 2.4.6+
-* PHP 8.2+
+* Adobe Commerce on cloud infrastructure or on-premises: 2.4.5+
+* PHP 8.1+
 * Magento Open Source is not supported.
 
 ## Installation
@@ -27,8 +27,14 @@ For more ideas on how you can use the tax module, refer to [tax use cases](./tax
 To enable out-of-process tax management in Adobe Commerce, install the `magento/module-out-of-process-tax-management` module using the following command:
 
 ```bash
- composer require magento/module-out-of-process-tax-management --with-dependencies
+composer require magento/module-out-of-process-tax-management --with-dependencies
 ```
+
+For Adobe Commerce version 2.4.5, run the following command if you encounter any issues during `magento setup:install` process:
+
+```bash
+magento setup:di:compile
+````
 
 ## Configuration
 


### PR DESCRIPTION
## Purpose of this pull request

- Update the minimum supported versions of:
  - Out-of-process Tax Commerce 2.4.5+, PHP 8.1+ ([CEXT-4724](https://jira.corp.adobe.com/browse/CEXT-4724))
  - Out-of-process Shipping PHP 8.1+ ([CEXT-4749](https://jira.corp.adobe.com/browse/CEXT-4749))
