### PR TITLE
fix links

### DIFF
--- a/src/pages/starter-kit/checkout/development.md
+++ b/src/pages/starter-kit/checkout/development.md
@@ -88,7 +88,7 @@ For debugging applications created with the starter kit, refer to the [App Build
 
 ## Testing
 
-The testing framework is in [Jest](https://jestjs.io) and execution is based on the [`aio` CLI](https://developer.adobe.com/runtime/docs/guides/tools/cli_install/).
+The testing framework is in [Jest](https://jestjs.io) and execution is based on the [`aio` CLI](https://developer.adobe.com/app-builder/docs/guides/runtime_guides/tools/cli-install).
 
 Run unit tests for the UI and actions:
 

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -24,7 +24,7 @@ You must install or have access to the following prerequisites to develop with t
   nvm install 22 && nvm use
   ```
 
-- [Adobe I/O CLI](https://developer.adobe.com/runtime/docs/guides/tools/cli_install/).
+- [Adobe I/O CLI](https://developer.adobe.com/app-builder/docs/guides/runtime_guides/tools/cli-install).
 
 - Access to the [Adobe Developer Console](https://console.adobe.io/) with an App
   Builder license. If you do not have access to the Adobe Developer Console or App Builder, refer to [get access to App Builder](https://developer.adobe.com/app-builder/docs/overview/getting_access/#get-access-to-app-builder).


### PR DESCRIPTION
This PR fixes a link to App Builder docs that the App Builder team changed but did not redirect.