### PR TITLE
Move webhook REST endpoints from services repo

### DIFF
--- a/src/pages/webhooks/api.md
+++ b/src/pages/webhooks/api.md
@@ -106,7 +106,7 @@ curl --request GET \
 
 <Edition name="saas" />
 
-To subscribe a webhook, make a `POST` request to the `/V1/webhooks/subscribe` endpoint. [Create a webhook](./create-webhook.md) provides details about the contents of a webhook.
+To subscribe a webhook, make a `POST` request to the `/V1/webhooks/subscribe` endpoint. [Create a webhook](./conditional-webhooks.md) provides details about the contents of a webhook.
 
 The following restrictions apply to the webhook request:
 
@@ -125,7 +125,7 @@ The request body must include the following attributes:
 |---|---|---|---|---|
 | `hook_name` | String | A hook name that is unique within a batch. This value must contain English alphanumeric characters and underscores (_) only.| true        | Not applicable     |
 | `url` | String | The HTTP endpoint to send the request for processing. | true        | Not applicable     |
-| `webhook_method` | String | The webhook code name. The value must be in the form `<type>.<webhook_name>`, where `type` is either `observer` or `plugin`, and `webhook_name` matches a valid [Commerce webhook name](index.md#webhooks). | true       | Not applicable    |
+| `webhook_method` | String | The webhook code name. The value must be in the form `<type>.<webhook_name>`, where `type` is either `observer` or `plugin`, and `webhook_name` matches a valid Commerce webhook name. | true       | Not applicable    |
 | `webhook_type` | String | Specifies whether to execute the webhook `before` or `after` the original action. | true | Not applicable |
 | `batch_name` | String | A unique name for the batch. This value must contain English alphanumeric characters and underscores (_) only.| true | Not applicable |
 

--- a/src/pages/webhooks/api.md
+++ b/src/pages/webhooks/api.md
@@ -16,44 +16,44 @@ The `GET /rest/all/V1/webhooks/list` endpoint returns a list of all subscribed w
 
 ```json
 [
-	{
-		"webhook_method": "observer.sales_order_place_before",
-		"webhook_type": "after",
-		"batch_name": "sales_order",
-		"batch_order": 100,
-		"hook_name": "sales_order_status",
-		"url": "/hook-url",
-		"priority": 100,
-		"required": true,
-		"soft_timeout": 1000,
-		"timeout": 2000,
-		"method": "",
-		"fallback_error_message": "Unable to validate product",
-		"ttl": 6000,
-		"fields": [
-			{
-				"name": "name",
-				"source": "data.product.name"
-			},
-			{
-				"name": "price",
-				"source": "data.product.price"
-			}
-		],
-		"rules": [
-			{
-				"field": "data.product.sku",
-				"operator": "regex",
-				"value": "\/.*car.*\/"
-			}
-		],
-		"headers": [
-			{
-				"name": "header-name",
-				"value": "header-value"
-			}
-		]
-	}
+    {
+        "webhook_method": "observer.sales_order_place_before",
+        "webhook_type": "after",
+        "batch_name": "sales_order",
+        "batch_order": 100,
+        "hook_name": "sales_order_status",
+        "url": "/hook-url",
+        "priority": 100,
+        "required": true,
+        "soft_timeout": 1000,
+        "timeout": 2000,
+        "method": "",
+        "fallback_error_message": "Unable to validate product",
+        "ttl": 6000,
+        "fields": [
+            {
+                "name": "name",
+                "source": "data.product.name"
+            },
+            {
+                "name": "price",
+                "source": "data.product.price"
+            }
+        ],
+        "rules": [
+            {
+                "field": "data.product.sku",
+                "operator": "regex",
+                "value": "\/.*car.*\/"
+            }
+        ],
+        "headers": [
+            {
+                "name": "header-name",
+                "value": "header-value"
+            }
+        ]
+    }
 ]
 ```
 
@@ -69,7 +69,7 @@ curl --request GET \
    --header 'Authorization: Bearer <TOKEN>'
 ```
 
-### Get supported webhooks for SaaS
+## Get supported webhooks for SaaS
 
 <Edition name="saas" />
 
@@ -77,15 +77,15 @@ The `GET /V1/webhooks/supportedList` endpoint returns the events supported in Ad
 
 ```json
 [
-	{
-		"name": "observer.sales_quote_add_item"
-	},
-	{
-		"name": "observer.checkout_cart_product_add_before"
-	},
-	{
-		"name": "observer.catalog_product_save_after"
-	},
+    {
+        "name": "observer.sales_quote_add_item"
+    },
+    {
+        "name": "observer.checkout_cart_product_add_before"
+    },
+    {
+        "name": "observer.catalog_product_save_after"
+    },
   ...
 ]
 ```
@@ -94,10 +94,105 @@ The access token used in the request must have access to the `Webhooks > Webhook
 
 **Example usage:**
 
-The following cURL command returns a list of all suported webhooks in SaaS.
+The following cURL command returns a list of all supported webhooks in SaaS.
 
 ```bash
 curl --request GET \
    --url <ADOBE_COMMERCE_SAAS_REST_ENDPOINT>/V1/webhooks/supportedList \
    --header 'Authorization: Bearer <TOKEN>'
+```
+
+## Subscribe a webhook
+
+<Edition name="saas" />
+
+To subscribe a webhook, make a `POST` request to the `/V1/webhooks/subscribe` endpoint. [Create a webhook](./create-webhook.md) provides details about the contents of a webhook.
+
+The following restrictions apply to the webhook request:
+
+- Any specified `fields` must have a `name`.
+  - `name` cannot be a null.
+- Any `rules` must have a `field`, `value`, and `operator`.
+  - `field` and `operator` cannot be null.
+  - The `operator` must be one of the supported options listed under [conditional webhooks](./conditional-webhooks.md).
+- Any `headers` must have a `name` and `value`.
+  - `name` and `value` cannot be null.
+- `timeout`, `ttl`, and `soft_timeout` must be non-negative integers.
+
+The request body must include the following attributes:
+
+| Attribute | Type   | Description  | Is required | Default |
+|---|---|---|---|---|
+| `hook_name` | String | A hook name that is unique within a batch. This value must contain English alphanumeric characters and underscores (_) only.| true        | Not applicable     |
+| `url` | String | The HTTP endpoint to send the request for processing. | true        | Not applicable     |
+| `webhook_method` | String | The webhook code name. The value must be in the form `<type>.<webhook_name>`, where `type` is either `observer` or `plugin`, and `webhook_name` matches a valid [Commerce webhook name](index.md#webhooks). | true       | Not applicable    |
+| `webhook_type` | String | Specifies whether to execute the webhook `before` or `after` the original action. | true | Not applicable |
+| `batch_name` | String | A unique name for the batch. This value must contain English alphanumeric characters and underscores (_) only.| true | Not applicable |
+
+### Request body
+
+```json
+{
+  "webhook": {
+    "webhook_method": "observer.checkout_cart_product_add_before",
+    "webhook_type": "after",
+    "batch_name": "add_product",
+    "batch_order": 100,
+    "hook_name": "validate_product",
+    "url": "https://<host>.com/validate-product-add",
+    "priority": 100,
+    "required": true,
+    "timeout": 2000,
+    "ttl": 6000,
+    "soft_timeout": 1000,
+    "fallback_error_message": "Unable to validate product",
+    "fields": [
+      {
+        "name": "name",
+        "source": "data.product.name"
+      },
+      {
+        "name": "price",
+        "source": "data.product.price"
+      }
+    ],
+    "rules": [
+      {
+        "field": "data.product.sku",
+        "operator": "regex",
+        "value": "/.*car.*/"
+      }
+    ],
+    "headers": [
+      {
+        "name": "CLIENT_ID",
+        "value": "abcasdf-12abcd3-45efabc4"
+      }
+    ]
+  }
+}
+```
+
+## Unsubscribe a webhook
+
+<Edition name="saas" />
+
+The unsubscribe endpoint allows you to delete an existing webhook subscription. To delete a webhook, make a `POST` request to the `/V1/webhooks/unsubscribe` endpoint. The request body must include the following attributes from the existing webhook:
+
+- `webhook_method`
+- `webhook_type`
+- `batch_name`
+- `hook_name`
+
+### Request body
+
+```json
+{
+  "webhook": {
+    "webhook_method": "observer.checkout_cart_product_add_before",
+    "webhook_type": "after",
+    "batch_name": "add_product",
+    "hook_name": "validate_product"
+  }
+}
 ```

--- a/src/pages/webhooks/create-webhooks.md
+++ b/src/pages/webhooks/create-webhooks.md
@@ -27,7 +27,7 @@ With this knowledge, you can create a webhook, which defines the following sets 
 
 * Optional rules that trigger only when certain conditions are met, such as when a string matches a specific value.
 
-In Adobe Commerce as a Cloud Service, you can create a webhook subscription in the Admin or by using a REST endpoint. (See [Webhooks in Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/services/cloud/guides/rest/webhooks/) for details on using REST.) In Platform as a Service (PaaS) and on-premises environments, you must create an `app/etc/webhooks.xml` file or create a custom module that includes a `<custom-module-root>/etc/webhooks.xml` file.
+In Adobe Commerce as a Cloud Service, you can create a webhook subscription in the Admin or by using a REST endpoint. (See [Subscribe a webhook](./api.md#subscribe-a-webhook) for details on using REST.) In Platform as a Service (PaaS) and on-premises environments, you must create an `app/etc/webhooks.xml` file or create a custom module that includes a `<custom-module-root>/etc/webhooks.xml` file.
 
 ## Define webhook properties
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds info about using REST on ACCS webhooks to the extensibility repo.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
