### PR TITLE
Alternative testing options for app submission

### DIFF
--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -152,6 +152,16 @@ To facilitate proper testing during review, ensure you provide:
 - Test credentials or demo environments (if applicable)
 - Documentation of any third-party service dependencies
 
+<InlineAlert variant="help" slots="header, text1, text2, text3" />
+
+Alternative options
+
+In cases where it is not possible to provide test credentials or a demo environment, such as when access restrictions or security concerns apply, consider the following options:
+
+**Option 1**: Coordinate a live demo with the Adobe review team
+
+**Option 2**: Submit a recorded video demonstrating the app's functionality to the Adobe review team
+
 ### Cleanup and quality assurance
 
 - Code cleanup


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds alternative options for app submission review/testing based on internal feedback.

## Affected pages

https://developer.adobe.com/commerce/extensibility/app-development/app-submission-guidelines/#runtime-and-testing

![Screenshot 2025-06-12 at 1 34 26 PM](https://github.com/user-attachments/assets/a06be75b-9159-456a-9c3a-2955dfb79f6f)

whatsnew
Added [alternative options](https://developer.adobe.com/commerce/extensibility/app-development/app-submission-guidelines/#runtime-and-testing) for app submission review/testing.