### PR TITLE
Add badging for eventing

### DIFF
--- a/src/_includes/conditional-event-example.md
+++ b/src/_includes/conditional-event-example.md
@@ -1,0 +1,8 @@
+The following example creates and registers a conditional event named `plugin.magento.catalog.model.resource_model.product.save_low_stock_event`. Its parent is `plugin.magento.catalog.model.resource_model.product.save`. It defines rules that trigger when all of the conditions are true:
+
+*  The value of `qty` is less than 20
+*  The `category_id` is either 3, 4, or 5
+*  The product `name` contains `TV`
+*  The `store_id` of product category is either 1 or 2
+
+These fields are present and declared in the parent event.

--- a/src/_includes/conditional-event-example.md
+++ b/src/_includes/conditional-event-example.md
@@ -1,8 +1,8 @@
 The following example creates and registers a conditional event named `plugin.magento.catalog.model.resource_model.product.save_low_stock_event`. Its parent is `plugin.magento.catalog.model.resource_model.product.save`. It defines rules that trigger when all of the conditions are true:
 
-*  The value of `qty` is less than 20
-*  The `category_id` is either 3, 4, or 5
+*  The value of `qty` is less than `20`
+*  The `category_id` is either `3`, `4`, or `5`
 *  The product `name` contains `TV`
-*  The `store_id` of product category is either 1 or 2
+*  The `store_id` of product category is either `1` or `2`
 
 These fields are present and declared in the parent event.

--- a/src/_includes/conditional-event.md
+++ b/src/_includes/conditional-event.md
@@ -23,7 +23,7 @@ Each rule contains the following:
    | `greaterThan` | Checks whether the value supplied in the payload of the event is greater than a specified value. Applicable for integer and float data types. |
    | `lessThan`    | Checks whether the payload value is less than a specified value. Applicable for integer and float data types. |
    | `equal`       | Checks whether the payload value matches the specified value. For Boolean data types, use `1` to compare to `true` and `0` to compare to `false`. |
-   | `regex`       | A regular expression that checks for matches. The specified value must be compatible with the [regular expression match](https://www.php.net/manual/en/function.preg-match.php) |
+   | `regex`       | A regular expression that checks for matches. The specified value must be compatible with the [regular expression match](https://www.php.net/manual/en/function.preg-match.php). |
    | `in`          | Checks whether the payload value is one of multiple specified values. The value must be a comma-separated list. You do not need to provide additional escape characters. |
 
 *  The value to compare against. When you assign the `regex` operator, you must delimit the regular expression value with valid characters, such as forward slashes (/). For example, `/^TV .*/i`, which checks whether the string starts with the string `TV`, ignoring the case of the letters.

--- a/src/_includes/conditional-event.md
+++ b/src/_includes/conditional-event.md
@@ -1,0 +1,29 @@
+You may decide that you want Adobe I/O Events for Adobe Commerce to notify the client application when certain conditions occur. For example, by default, if you register an event that tracks the remaining quantity of a product, the eventing service sends that information to your client application each time Commerce emits the event. However, you might be interested in the remaining quantity only when it reaches a specific threshold, such as 20 units. Conditional events allow you to define exactly when to send events to your application. Otherwise, the client application must include code to filter out the unimportant and unnecessary data.
+
+A conditional event acts as an extension of a custom or native Commerce event. You must specify the source, or parent, event and define one or more rules that evaluate the data that is present in the parent event payload. If all the individual rules defined in a conditional event evaluate as true, then the eventing service sends the conditional event to the application. If one or more rules evaluate as false, the service sends neither the parent event nor the conditional event, unless the parent has been subscribed separately, without any rules.
+
+All conditional events contain the following information:
+
+*  A unique name for the conditional event.
+
+*  The name of the parent event. You must attach a conditional event to a specific registered event.
+
+*  One or more rules.
+
+Each rule contains the following:
+
+*  A field that is defined in the parent event.
+
+*  An operator, which is represented as a comparison statement between the value supplied in the parent event's payload and the threshold value.
+
+   The operator must be one of the following:
+
+   | Operator      | Description |
+   | -----------   | ----------- |
+   | `greaterThan` | Checks whether the value supplied in the payload of the event is greater than a specified value. Applicable for integer and float data types. |
+   | `lessThan`    | Checks whether the payload value is less than a specified value. Applicable for integer and float data types. |
+   | `equal`       | Checks whether the payload value matches the specified value. For Boolean data types, use `1` to compare to `true` and `0` to compare to `false`. |
+   | `regex`       | A regular expression that checks for matches. The specified value must be compatible with the [regular expression match](https://www.php.net/manual/en/function.preg-match.php) |
+   | `in`          | Checks whether the payload value is one of multiple specified values. The value must be a comma-separated list. You do not need to provide additional escape characters. |
+
+*  The value to compare against. When you assign the `regex` operator, you must delimit the regular expression value with valid characters, such as forward slashes (/). For example, `/^TV .*/i`, which checks whether the string starts with the string `TV`, ignoring the case of the letters.

--- a/src/_includes/nested-event.md
+++ b/src/_includes/nested-event.md
@@ -1,0 +1,129 @@
+When the payload contains an array of objects, use the following construction to register specific fields from that array:
+
+```text
+<object_name>[].<field_name>
+```
+
+For example, the payload of the `observer.sales_order_invoice_save_after` event contains a top-level `items[]` array. In this case, the array contains details about two individual products.
+
+```json
+{
+  "event": {
+    "data": {
+      "value": {
+        "order_id": "8",
+        "store_id": "1",
+        "customer_id": null,
+        "billing_address_id": "16",
+        "shipping_address_id": "15",
+        "global_currency_code": "USD",
+        "base_currency_code": "USD",
+        "store_currency_code": "USD",
+        "order_currency_code": "USD",
+        "store_to_base_rate": "0.0000",
+        "store_to_order_rate": "0.0000",
+        "base_to_global_rate": "1.0000",
+        "base_to_order_rate": "1.0000",
+        "discount_description": null,
+        "items": [
+          {
+            "order_item_id": "8",
+            "product_id": "22",
+            "sku": "simple-product-2",
+            "name": "Simple Product 2",
+            "description": null,
+            "price": 200,
+            "base_price": "200.0000",
+            "base_cost": null,
+            "price_incl_tax": "200.0000",
+            "base_price_incl_tax": "200.0000",
+            "extension_attributes": {},
+            "weee_tax_applied": "[]",
+            "weee_tax_applied_amount": null,
+            "weee_tax_applied_row_amount": 0,
+            "base_weee_tax_applied_amount": null,
+            "base_weee_tax_applied_row_amnt": null,
+            "weee_tax_disposition": null,
+            "base_weee_tax_disposition": null,
+            "weee_tax_row_disposition": 0,
+            "base_weee_tax_row_disposition": 0,
+            "qty": "3.000000",
+            "invoice": {},
+            "parent_id": null,
+            "store_id": "1",
+            "row_total": 600,
+            "base_row_total": 600,
+            "row_total_incl_tax": 600,
+            "base_row_total_incl_tax": 600,
+            "tax_amount": 0,
+            "base_tax_amount": 0,
+            "discount_tax_compensation_amount": 0,
+            "base_discount_tax_compensation_amount": 0,
+            "base_weee_tax_applied_row_amount": 0
+          },
+          {
+            "order_item_id": "9",
+            "product_id": "21",
+            "sku": "simple-product-1",
+            "name": "Simple Product 1",
+            "description": null,
+            "price": 100,
+            "base_price": "100.0000",
+            "base_cost": null,
+            "price_incl_tax": "100.0000",
+            "base_price_incl_tax": "100.0000",
+            "extension_attributes": {},
+            "weee_tax_applied": "[]",
+            "weee_tax_applied_amount": null,
+            "weee_tax_applied_row_amount": 0,
+            "base_weee_tax_applied_amount": null,
+            "base_weee_tax_applied_row_amnt": null,
+            "weee_tax_disposition": null,
+            "base_weee_tax_disposition": null,
+            "weee_tax_row_disposition": 0,
+            "base_weee_tax_row_disposition": 0,
+            "qty": "5.000000",
+            "invoice": {},
+            "parent_id": null,
+            "store_id": "1",
+            "row_total": 500,
+            "base_row_total": 500,
+            "row_total_incl_tax": 500,
+            "base_row_total_incl_tax": 500,
+            "tax_amount": 0,
+            "base_tax_amount": 0,
+            "discount_tax_compensation_amount": 0,
+            "base_discount_tax_compensation_amount": 0,
+            "base_weee_tax_applied_row_amount": 0
+          }
+        ],
+        "total_qty": 8,
+        "subtotal": 1100,
+        "base_subtotal": 1100,
+        "subtotal_incl_tax": 1100,
+        "base_subtotal_incl_tax": 1100,
+        "grand_total": 1100,
+        "base_grand_total": 1100,
+        "discount_amount": 0,
+        "base_discount_amount": 0,
+        "tax_amount": 0,
+        "base_tax_amount": 0,
+        "discount_tax_compensation_amount": 0,
+        "base_discount_tax_compensation_amount": 0,
+        "base_cost": 0,
+        "base_gift_cards_amount": 0,
+        "gift_cards_amount": 0,
+        "can_void_flag": false,
+        "state": 2,
+        "increment_id": "000000013",
+        "entity_id": "13",
+        "id": "13",
+        "created_at": "2023-04-06 18:36:18",
+        "updated_at": "2023-04-06 18:36:18"
+      }
+    }
+  }
+}
+```
+
+To register the top-level `order_id` field and the `sku` and `qty` of each product, define the subscription as follows:

--- a/src/_includes/sample-event.md
+++ b/src/_includes/sample-event.md
@@ -1,0 +1,131 @@
+For each event you register, you must define which fields to transmit to your App Builder application. The payload of an event can be massive. In addition, some events include sensitive or PCI compliance data by default. The payload of the `observer.catalog_product_save_after` event is similar to the following:
+
+```json
+{
+   "event":{
+      "data":{
+         "value":{
+            "_edit_mode":true,
+            "store_id":"0",
+            "entity_id":"3",
+            "attribute_set_id":"4",
+            "type_id":"simple",
+            "sku":"test2",
+            "has_options":false,
+            "required_options":false,
+            "created_at":"2022-07-28 14:13:40",
+            "updated_at":"2022-09-06 20:37:25",
+            "row_id":"3",
+            "created_in":"1",
+            "updated_in":"2147483647",
+            "name":"test2",
+            "meta_title":"test2",
+            "meta_description":"test2 ",
+            "page_layout":"product-full-width",
+            "options_container":"container2",
+            "url_key":"test2",
+            "msrp_display_actual_price_type":"0",
+            "gift_message_available":"2",
+            "gift_wrapping_available":"2",
+            "is_returnable":"2",
+            "status":"1",
+            "visibility":"4",
+            "tax_class_id":"2",
+            "price":"123.000000",
+            "meta_keyword":"test2",
+            "options":[
+               
+            ],
+            "media_gallery":{
+               "images":[
+                  
+               ],
+               "values":[
+                  
+               ]
+            },
+            "tier_price":[
+               
+            ],
+            "tier_price_changed":0,
+            "quantity_and_stock_status":{
+               "is_in_stock":"1",
+               "qty":"333"
+            },
+            "category_ids":[
+               "4"
+            ],
+            "is_salable":1,
+            "stock_data":{
+               "item_id":"3",
+               "product_id":"3",
+               "stock_id":"1",
+               "qty":"333",
+               "min_qty":"0",
+               "use_config_min_qty":"1",
+               "is_qty_decimal":"0",
+               "backorders":"0",
+               "use_config_backorders":"1",
+               "min_sale_qty":"1",
+               "use_config_min_sale_qty":"1",
+               "max_sale_qty":"10000",
+               "use_config_max_sale_qty":"1",
+               "is_in_stock":"1",
+               "notify_stock_qty":"1",
+               "use_config_notify_stock_qty":"1",
+               "manage_stock":"1",
+               "use_config_manage_stock":"1",
+               "stock_status_changed_auto":"0",
+               "use_config_qty_increments":"1",
+               "qty_increments":"1",
+               "use_config_enable_qty_inc":"1",
+               "enable_qty_increments":"0",
+               "is_decimal_divided":0,
+               "website_id":"0",
+               "deferred_stock_update":"0",
+               "use_config_deferred_stock_update":"1",
+               "type_id":"simple",
+               "min_qty_allowed_in_shopping_cart":[
+
+               ]
+            },
+            "use_config_gift_message_available":"1",
+            "use_config_gift_wrapping_available":"1",
+            "current_product_id":"3",
+            "affect_product_custom_options":"1",
+            "current_store_id":"0",
+            "product_has_weight":"1",
+            "is_new":"0",
+            "website_ids":{
+               "1":"1"
+            },
+            "url_key_create_redirect":"test2",
+            "ignore_links_flag":false,
+            "can_save_custom_options":true,
+            "save_rewrites_history":true,
+            "can_save_bundle_selections":false,
+            "is_custom_option_changed":true,
+            "parent_id":0,
+            "special_from_date_is_formated":true,
+            "custom_design_from_is_formated":true,
+            "news_from_date_is_formated":true,
+            "news_to_date_is_formated":true,
+            "is_changed_categories":false,
+            "is_changed_websites":false,
+            "force_reindex_eav_required":true
+         },
+         "_metadata":{
+            "commerceEdition":"Adobe Commerce",
+            "commerceVersion":"2.4.6-beta5",
+            "eventsClientVersion":"1.0.1",
+            "storeId":"0",
+            "websiteId":"1",
+            "storeGroupId":"0"
+         },
+         "source":"demo.demo"
+      }
+   }
+}
+```
+
+You define an array of fields to transmit in your configuration file. Specify any field within an event's `value` object to ensure it is transmitted to an application. If the field is part of a secondary object, such as `stock_data` in the above example, use the format `<object-name>.field`. For example: `stock_data.product_id`.

--- a/src/data/navigation/sections/events.js
+++ b/src/data/navigation/sections/events.js
@@ -20,16 +20,16 @@ module.exports = [
     path: "/events/configure-additional-event-providers.md",
   },
   {
-    title: "Module development",
+    title: "Create events from the Admin",
+    path: "/events/create-events.md",
+  },
+  {
+    title: "Create events",
     path: "/events/module-development.md",
   },
   {
     title: "Create conditional events",
     path: "/events/conditional-events.md",
-  },
-  {
-    title: "Create events from the Admin",
-    path: "/events/create-events.md",
   },
   {
     title: "Add custom fields",

--- a/src/pages/events/api.md
+++ b/src/pages/events/api.md
@@ -489,15 +489,15 @@ The `GET /V1/eventing/supportedList` endpoint returns the events supported in Ad
 
 ```json
 [
-	{
-		"name": "observer.customer_login"
-	},
-	{
-		"name": "observer.customer_register_success"
-	},
-	{
-		"name": "observer.customer_save_after"
-	},
+    {
+        "name": "observer.customer_login"
+    },
+    {
+        "name": "observer.customer_register_success"
+    },
+    {
+        "name": "observer.customer_save_after"
+    },
   ...
 ]
 ```

--- a/src/pages/events/commands.md
+++ b/src/pages/events/commands.md
@@ -1,6 +1,7 @@
 ---
 title: Event management commands
 description: Provides details about the commands needed to set up Adobe I/O Events for Adobe Commerce.
+edition: paas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/conditional-events.md
+++ b/src/pages/events/conditional-events.md
@@ -1,55 +1,24 @@
 ---
 title: Create conditional events
 description: Create custom Adobe Commerce conditional events using declarative configuration.
+edition: paas
 keywords:
   - Events
   - Extensibility
 ---
 
+import ConditionalEvents from '/src/_includes/conditional-event.md'
+import ConditionalEventExample from '/src/_includes/conditional-event-example.md'
+
 # Create conditional events
 
-You may decide that you want Adobe I/O Events for Adobe Commerce to notify the client application when certain conditions occur. For example, by default, if you register an event that tracks the remaining quantity of a product, the eventing service sends that information to your client application each time Commerce emits the event. However, you might be interested in the remaining quantity only when it reaches a specific threshold, such as 20 units. Conditional events allow you to define exactly when to send events to your application. Otherwise, the client application must include code to filter out the unimportant and unnecessary data.
-
-A conditional event acts as an extension of a custom or native Commerce event. You must specify the source, or parent, event and define one or more rules that evaluate the data that is present in the parent event payload. If all the individual rules defined in a conditional event evaluate as true, then the eventing service sends the conditional event to the application. If one or more rules evaluate as false, the service sends neither the parent event nor the conditional event, unless the parent has been subscribed separately, without any rules.
-
-All conditional events contain the following information:
-
-*  A unique name for the conditional event.
-
-*  The name of the parent event. You must attach a conditional event to a specific registered event.
-
-*  One or more rules.
-
-Each rule contains the following:
-
-*  A field that is defined in the parent event.
-
-*  An operator, which is represented as a comparison statement between the value supplied in the parent event's payload and the threshold value.
-
-   The operator must be one of the following:
-
-   | Operator      | Description |
-   | -----------   | ----------- |
-   | `greaterThan` | Checks whether the value supplied in the payload of the event is greater than a specified value. Applicable for integer and float data types. |
-   | `lessThan`    | Checks whether the payload value is less than a specified value. Applicable for integer and float data types. |
-   | `equal`       | Checks whether the payload value matches the specified value. For Boolean data types, use `1` to compare to `true` and `0` to compare to `false`. |
-   | `regex`       | A regular expression that checks for matches. The specified value must be compatible with the [regular expression match](https://www.php.net/manual/en/function.preg-match.php) |
-   | `in`          | Checks whether the payload value is one of multiple specified values. The value must be a comma-separated list. You do not need to provide additional escape characters. |
-
-*  The value to compare against. When you assign the `regex` operator, you must delimit the regular expression value with valid characters, such as forward slashes (/). For example, `/^TV .*/i`, which checks whether the string starts with the string `TV`, ignoring the case of the letters.
+<ConditionalEvents />
 
 You can create conditional events within your module's or root `io_events.xml` file or from the command line.
 
 ## Define conditional events in `io_events.xml`
 
-The following example creates and registers a conditional event named `plugin.magento.catalog.model.resource_model.product.save_low_stock_event`. Its parent is `plugin.magento.catalog.model.resource_model.product.save`. It defines rules that trigger when all of the conditions are true:
-
-*  The value of `qty` is less than 20
-*  The `category_id` is either 3, 4, or 5
-*  The product `name` contains `TV`
-*  The `store_id` of product category is either 1 or 2
-
-These fields are present and declared in the parent event.
+<ConditionalEventExample />
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="...">

--- a/src/pages/events/configure-additional-event-providers.md
+++ b/src/pages/events/configure-additional-event-providers.md
@@ -1,6 +1,7 @@
 ---
 title: Configure Additional Event Providers
 description: Learn how to configure additional event providers in Adobe Commerce.
+edition: saas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/configure-additional-event-providers.md
+++ b/src/pages/events/configure-additional-event-providers.md
@@ -1,7 +1,6 @@
 ---
 title: Configure Additional Event Providers
 description: Learn how to configure additional event providers in Adobe Commerce.
-edition: saas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/configure-commerce.md
+++ b/src/pages/events/configure-commerce.md
@@ -42,7 +42,15 @@ You must configure Commerce to communicate with your project. Configuration incl
 
 Create an event provider in Adobe I/O Events to associate the Commerce Events subscriptions with the provider. The event subscriptions in Adobe Commerce are created as event metadata in Adobe I/O Events infrastructure.
 
-Each event provider can link to multiple event subscriptions (event metadata). The event's subscriptions will be automatically linked to your event provider whenever you subscribe with the `events:subscribe` command. You can also manually synchronize all subscriptions with the `events:metadata:populate` command or by clicking the **Execute Synchronization** button on the **General configuration** section of the Adobe I/O Events page in the Admin. Running the `setup:upgrade` command also synchronizes events subscriptions.
+Each event provider can link to multiple event subscriptions (event metadata). The event's subscriptions will be automatically linked to your event provider whenever you:
+
+* Click the **Execute Synchronization** button on the **General configuration** section of the Adobe I/O Events page in the Admin.
+
+* &#8203;<Edition name="paas" /> Subscribe with the `events:subscribe` command.
+
+* &#8203;<Edition name="paas" /> Manually synchronize all subscriptions with the `events:metadata:populate` command.
+
+* &#8203;<Edition name="paas" /> Run the `setup:upgrade` command also synchronizes events subscriptions.
 
 You can find the list of event providers created in your organization, in the App Builder UI when [creating an Event Registration in App Builder](#subscribe-and-register-events).
 
@@ -55,6 +63,8 @@ You cannot create an event provider until you have configured and saved instance
 You can create an event provider using either the [Command line](./configure-commerce.md#command-line) or [Commerce Admin](./configure-commerce.md#commerce-admin).
 
 ### Command line
+
+<Edition name="paas" />
 
 1. Run the following command to create an event provider:
 
@@ -107,9 +117,9 @@ You can create an event provider using either the [Command line](./configure-com
 
    **Note**: The **Merchant ID** and **Environment ID** fields only support alphanumeric characters and underscores.
 
-```javascript
-"source": "<merchant-id>.<environment-id>"
-```
+   ```javascript
+   "source": "<merchant-id>.<environment-id>"
+   ```
 
 1. (Optional) By default, if an error occurs when Adobe Commerce attempts to send an event to Adobe I/O, Commerce retries a maximum of seven times. To change this value, uncheck the **Use system value** checkbox and set a new value in the **Maximum retries to send events** field.
 
@@ -125,7 +135,7 @@ You must define which Commerce events to subscribe to, then register them in the
 
 Commerce provides two sources for events: observers and plugins. You must specify the source as part of the event name. See [Subscribe to a Commerce event](./commands.md) for details about the syntax of the `events:subscribe` command.
 
-1. If you don't have a module ready for integration with Adobe I/O Events, or you don't know exactly which events to register at this point, use the `events:subscribe` command to subscribe to some sample events, as shown in the following example commands:
+1. &#8203;<Edition name="paas" />  If you don't have a module ready for integration with Adobe I/O Events, or you don't know exactly which events to register at this point, use the `events:subscribe` command to subscribe to some sample events, as shown in the following example commands:
 
    ```bash
    bin/magento events:subscribe observer.catalog_product_save_after --fields=sku --fields=stock_data.qty
@@ -304,6 +314,8 @@ If you want to add `Event Registrations` with `Runtime Actions` as event consume
 [App Builder with IO Events](https://developer.adobe.com/events/docs/guides/appbuilder/#initialising-an-app-builder-app-with-io-events-template) provides additional information about setting up App Builder projects.
 
 ## Check cron and message queue configuration
+
+<Edition name="paas" />
 
 Cron and message queues must be enabled. Commerce uses the `event_data_batch_send` cron job to transmit batches of event messages and the `clean_event_data` cron job to remove these messages from the database. These cron jobs are part of the `default` group.
 

--- a/src/pages/events/convert-field-values.md
+++ b/src/pages/events/convert-field-values.md
@@ -1,6 +1,7 @@
 ---
 title: Convert payload field values
-description: Learn how to convert a field value based on a condition
+description: Learn how to convert a field value based on a condition.
+edition: paas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/create-events.md
+++ b/src/pages/events/create-events.md
@@ -7,6 +7,10 @@ keywords:
 edition: saas
 ---
 
+import SampleEvent from '/src/_includes/sample-event.md'
+import NestedEvent from '/src/_includes/nested-event.md'
+import ConditionalEvents from '/src/_includes/conditional-event.md'
+
 # Create events from the Admin
 
 <InlineAlert variant="info" slots="text1" />
@@ -41,17 +45,85 @@ Field | Description
 
 ### Configure event subscription fields
 
-The **Event Subscription Fields** configuration panel allows you to define the fields of the event payload to transmit from Commerce. The name provides the path to the field in the event payload. See [Register events](./module-development.md#register-events) for details on specifying event field names.
+The **Event Subscription Fields** configuration panel allows you to define the fields of the event payload to transmit from Commerce. The name provides the path to the field in the event payload.
+
+<SampleEvent />
+
+<InlineAlert variant="info" slots="text" />
+
+If you do not specify any fields, Commerce sends the entire event payload. Adobe recommends sending a limited number of fields per event. If you send all fields, you increase the risk of including sensitive or PCI compliance data in the event. In addition, specifying only the fields that are applicable to your business case is recommended for optimal performance and cost effectiveness.
+
+The following example shows how three fields can be configured for the `observer.catalog_product_save_after` event:
+
+```yaml
+Name: entity_id
+Name: sku
+Name: is_new
+```
+
+The contents of an `observer.catalog_product_save_after` event are similar to the following:
+
+```json
+{
+    "value": {
+    "entity_id": "3",
+    "sku": "test2",
+    "is_new": "0"
+  }
+}
+```
+
+### Array of nested objects
+
+<NestedEvent />
+
+```yaml
+Name: order_id
+Name: items[].sku
+Name: items[].qty
+```
+
+The contents of the transmitted event are similar to the following:
+
+```json
+{
+   "order_id": "8",
+   "items": [
+      {
+         "sku": "simple-product-2",
+         "qty": "3.000000"
+      },
+      {
+         "sku": "simple-product-1",
+         "qty": "5.000000"
+      }
+   ]
+}
+```
 
 ### Configure event subscription rules
 
-The **Event Subscription Rules** configuration panel allows you to define rules that determine when an event with a name alias is triggered. [Create conditional events](./conditional-events.md) describes how to configure rules.
+<ConditionalEvents />
 
-Field | Description
---- | ---
-**Field** | The name of the event field to be evaluated.
-**Value** | The value to be compared.
-**Operator** | Defines which comparison operator to use. Examples include `lessThan`, `regex`, and `equal`.
+### Example
+
+```yaml
+Field: qty
+Operator: lessThan
+Value: 20
+
+Field: category_id
+Operator: in
+Value: 3,4,5
+
+Field: name
+Operator: regex
+Value: /^TV .*/i
+
+Field: category.store_id
+Operator: in
+Value: 1,2
+```
 
 ## Events Subscriptions grid actions
 

--- a/src/pages/events/create-events.md
+++ b/src/pages/events/create-events.md
@@ -65,15 +65,13 @@ The contents of an `observer.catalog_product_save_after` event are similar to th
 
 ```json
 {
-    "value": {
     "entity_id": "3",
     "sku": "test2",
     "is_new": "0"
-  }
 }
 ```
 
-### Array of nested objects
+#### Array of nested objects
 
 <NestedEvent />
 
@@ -105,7 +103,7 @@ The contents of the transmitted event are similar to the following:
 
 <ConditionalEvents />
 
-### Example
+#### Example
 
 ```yaml
 Field: qty

--- a/src/pages/events/custom-event-fields.md
+++ b/src/pages/events/custom-event-fields.md
@@ -1,6 +1,7 @@
 ---
 title: Add custom fields to an event
 description: Learn how to add custom fields to an event.
+edition: paas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/installation.md
+++ b/src/pages/events/installation.md
@@ -1,6 +1,7 @@
 ---
 title: Install Adobe I/O Events for Adobe Commerce
 description: Learn how to install the Commerce modules needed for Adobe I/O Events for Adobe Commerce.
+edition: paas
 keywords:
   - Events
   - Extensibility

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -1,10 +1,14 @@
 ---
 title: Commerce module development
 description: Learn what you need to do to enable your modules for Adobe I/O Events.
+edition: paas
 keywords:
   - Events
   - Extensibility
 ---
+
+import SampleEvent from '/src/_includes/sample-event.md'
+import NestedEvent from '/src/_includes/nested-event.md'
 
 # Commerce module development
 
@@ -31,137 +35,7 @@ You can programmatically register events using the following methods:
 *  Create an `io_events.xml` file in your module or in the root `app/etc` directory
 *  Declare them in the system `env.php` or `config.php` file
 
-For each event you register, you must define which fields to transmit to your App Builder application. The payload of an event can be massive. In addition, some events include sensitive or PCI compliance data by default. The payload of the `observer.catalog_product_save_after` event is similar to the following:
-
-```json
-{
-   "event":{
-      "data":{
-         "value":{
-            "_edit_mode":true,
-            "store_id":"0",
-            "entity_id":"3",
-            "attribute_set_id":"4",
-            "type_id":"simple",
-            "sku":"test2",
-            "has_options":false,
-            "required_options":false,
-            "created_at":"2022-07-28 14:13:40",
-            "updated_at":"2022-09-06 20:37:25",
-            "row_id":"3",
-            "created_in":"1",
-            "updated_in":"2147483647",
-            "name":"test2",
-            "meta_title":"test2",
-            "meta_description":"test2 ",
-            "page_layout":"product-full-width",
-            "options_container":"container2",
-            "url_key":"test2",
-            "msrp_display_actual_price_type":"0",
-            "gift_message_available":"2",
-            "gift_wrapping_available":"2",
-            "is_returnable":"2",
-            "status":"1",
-            "visibility":"4",
-            "tax_class_id":"2",
-            "price":"123.000000",
-            "meta_keyword":"test2",
-            "options":[
-               
-            ],
-            "media_gallery":{
-               "images":[
-                  
-               ],
-               "values":[
-                  
-               ]
-            },
-            "tier_price":[
-               
-            ],
-            "tier_price_changed":0,
-            "quantity_and_stock_status":{
-               "is_in_stock":"1",
-               "qty":"333"
-            },
-            "category_ids":[
-               "4"
-            ],
-            "is_salable":1,
-            "stock_data":{
-               "item_id":"3",
-               "product_id":"3",
-               "stock_id":"1",
-               "qty":"333",
-               "min_qty":"0",
-               "use_config_min_qty":"1",
-               "is_qty_decimal":"0",
-               "backorders":"0",
-               "use_config_backorders":"1",
-               "min_sale_qty":"1",
-               "use_config_min_sale_qty":"1",
-               "max_sale_qty":"10000",
-               "use_config_max_sale_qty":"1",
-               "is_in_stock":"1",
-               "notify_stock_qty":"1",
-               "use_config_notify_stock_qty":"1",
-               "manage_stock":"1",
-               "use_config_manage_stock":"1",
-               "stock_status_changed_auto":"0",
-               "use_config_qty_increments":"1",
-               "qty_increments":"1",
-               "use_config_enable_qty_inc":"1",
-               "enable_qty_increments":"0",
-               "is_decimal_divided":0,
-               "website_id":"0",
-               "deferred_stock_update":"0",
-               "use_config_deferred_stock_update":"1",
-               "type_id":"simple",
-               "min_qty_allowed_in_shopping_cart":[
-
-               ]
-            },
-            "use_config_gift_message_available":"1",
-            "use_config_gift_wrapping_available":"1",
-            "current_product_id":"3",
-            "affect_product_custom_options":"1",
-            "current_store_id":"0",
-            "product_has_weight":"1",
-            "is_new":"0",
-            "website_ids":{
-               "1":"1"
-            },
-            "url_key_create_redirect":"test2",
-            "ignore_links_flag":false,
-            "can_save_custom_options":true,
-            "save_rewrites_history":true,
-            "can_save_bundle_selections":false,
-            "is_custom_option_changed":true,
-            "parent_id":0,
-            "special_from_date_is_formated":true,
-            "custom_design_from_is_formated":true,
-            "news_from_date_is_formated":true,
-            "news_to_date_is_formated":true,
-            "is_changed_categories":false,
-            "is_changed_websites":false,
-            "force_reindex_eav_required":true
-         },
-         "_metadata":{
-            "commerceEdition":"Adobe Commerce",
-            "commerceVersion":"2.4.6-beta5",
-            "eventsClientVersion":"1.0.1",
-            "storeId":"0",
-            "websiteId":"1",
-            "storeGroupId":"0"
-         },
-         "source":"demo.demo"
-      }
-   }
-}
-```
-
-You define an array of fields to transmit in your configuration file. Specify any field within an event's `value` object to ensure it is transmitted to an application. If the field is part of a secondary object, such as `stock_data` in the above example, use the format `<object-name>.field`. For example: `stock_data.product_id`.
+<SampleEvent />
 
 After you've registered at least one event, run the [events:generate:module command](./commands.md#generate-a-commerce-module-based-on-a-list-of-subscribed-events) to generate the required plugins.
 
@@ -176,8 +50,6 @@ You can transmit all the fields within an event by setting the value of the `fie
 Adobe recommends sending a limited number of fields per event. If you send all fields, you increase the risk of including sensitive or PCI compliance data in the event. In addition, specifying only the fields that are applicable to your business case is recommended for optimal performance and cost effectiveness.
 
 [Add custom fields to an event](custom-event-fields.md) describes how to enhance the payload of pre-defined events.
-
-The following example registers multiple events. The `<fields>` element defines the contents of each transmitted event.
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module-commerce-events-client/etc/io_events.xsd">
@@ -227,135 +99,7 @@ The `<field>` element can also contain the `converter` attribute. Use this attri
 
 ### Array of nested objects
 
-When the payload contains an array of objects, use the following construction to register specific fields from that array:
-
-```text
-<object_name>[].<field_name>
-```
-
-For example, the payload of the `observer.sales_order_invoice_save_after` event contains a top-level `items[]` array. In this case, the array contains details about two individual products.
-
-```json
-{
-  "event": {
-    "data": {
-      "value": {
-        "order_id": "8",
-        "store_id": "1",
-        "customer_id": null,
-        "billing_address_id": "16",
-        "shipping_address_id": "15",
-        "global_currency_code": "USD",
-        "base_currency_code": "USD",
-        "store_currency_code": "USD",
-        "order_currency_code": "USD",
-        "store_to_base_rate": "0.0000",
-        "store_to_order_rate": "0.0000",
-        "base_to_global_rate": "1.0000",
-        "base_to_order_rate": "1.0000",
-        "discount_description": null,
-        "items": [
-          {
-            "order_item_id": "8",
-            "product_id": "22",
-            "sku": "simple-product-2",
-            "name": "Simple Product 2",
-            "description": null,
-            "price": 200,
-            "base_price": "200.0000",
-            "base_cost": null,
-            "price_incl_tax": "200.0000",
-            "base_price_incl_tax": "200.0000",
-            "extension_attributes": {},
-            "weee_tax_applied": "[]",
-            "weee_tax_applied_amount": null,
-            "weee_tax_applied_row_amount": 0,
-            "base_weee_tax_applied_amount": null,
-            "base_weee_tax_applied_row_amnt": null,
-            "weee_tax_disposition": null,
-            "base_weee_tax_disposition": null,
-            "weee_tax_row_disposition": 0,
-            "base_weee_tax_row_disposition": 0,
-            "qty": "3.000000",
-            "invoice": {},
-            "parent_id": null,
-            "store_id": "1",
-            "row_total": 600,
-            "base_row_total": 600,
-            "row_total_incl_tax": 600,
-            "base_row_total_incl_tax": 600,
-            "tax_amount": 0,
-            "base_tax_amount": 0,
-            "discount_tax_compensation_amount": 0,
-            "base_discount_tax_compensation_amount": 0,
-            "base_weee_tax_applied_row_amount": 0
-          },
-          {
-            "order_item_id": "9",
-            "product_id": "21",
-            "sku": "simple-product-1",
-            "name": "Simple Product 1",
-            "description": null,
-            "price": 100,
-            "base_price": "100.0000",
-            "base_cost": null,
-            "price_incl_tax": "100.0000",
-            "base_price_incl_tax": "100.0000",
-            "extension_attributes": {},
-            "weee_tax_applied": "[]",
-            "weee_tax_applied_amount": null,
-            "weee_tax_applied_row_amount": 0,
-            "base_weee_tax_applied_amount": null,
-            "base_weee_tax_applied_row_amnt": null,
-            "weee_tax_disposition": null,
-            "base_weee_tax_disposition": null,
-            "weee_tax_row_disposition": 0,
-            "base_weee_tax_row_disposition": 0,
-            "qty": "5.000000",
-            "invoice": {},
-            "parent_id": null,
-            "store_id": "1",
-            "row_total": 500,
-            "base_row_total": 500,
-            "row_total_incl_tax": 500,
-            "base_row_total_incl_tax": 500,
-            "tax_amount": 0,
-            "base_tax_amount": 0,
-            "discount_tax_compensation_amount": 0,
-            "base_discount_tax_compensation_amount": 0,
-            "base_weee_tax_applied_row_amount": 0
-          }
-        ],
-        "total_qty": 8,
-        "subtotal": 1100,
-        "base_subtotal": 1100,
-        "subtotal_incl_tax": 1100,
-        "base_subtotal_incl_tax": 1100,
-        "grand_total": 1100,
-        "base_grand_total": 1100,
-        "discount_amount": 0,
-        "base_discount_amount": 0,
-        "tax_amount": 0,
-        "base_tax_amount": 0,
-        "discount_tax_compensation_amount": 0,
-        "base_discount_tax_compensation_amount": 0,
-        "base_cost": 0,
-        "base_gift_cards_amount": 0,
-        "gift_cards_amount": 0,
-        "can_void_flag": false,
-        "state": 2,
-        "increment_id": "000000013",
-        "entity_id": "13",
-        "id": "13",
-        "created_at": "2023-04-06 18:36:18",
-        "updated_at": "2023-04-06 18:36:18"
-      }
-    }
-  }
-}
-```
-
-To register the top-level `order_id` field and the `sku` and `qty` of each product, define the subscription as follows:
+<NestedEvent />
 
 ```xml
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module-commerce-events-client/etc/io_events.xsd">


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds badging for Eventing. I was able to keep SaaS and PaaS discussions in separate topics for the most part, because event definitions are much simpler than in webhooks. I converted several passages to include files.

Staging build: https://adobedocs.github.io/commerce-extensibility/events/

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
