### PR TITLE
fix: 404 in webhooks TOC

### DIFF
--- a/src/data/navigation/sections/webhooks.js
+++ b/src/data/navigation/sections/webhooks.js
@@ -111,9 +111,5 @@ module.exports = [
       title: "Release notes",
       path: "/webhooks/release-notes.md",
     },
-    {
-      title: "Tutorial",
-      path: "/webhooks/extend-commerce-webhooks.md"
-    }
   ];
   


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a TOC entry in the webhooks guide that 404s.

<img width="1188" height="723" alt="Screenshot 2025-07-28 at 12 23 04 PM" src="https://github.com/user-attachments/assets/fff6db9a-9e01-4da5-8897-96b027acfc65" />
