### PR TITLE
CEXT-4871: Updated doc for multi-event provider support in Checkout Starter Kit

### DIFF
--- a/src/pages/starter-kit/checkout/configure.md
+++ b/src/pages/starter-kit/checkout/configure.md
@@ -72,6 +72,8 @@ To configure eventing, follow these steps:
 
         - The environment variable `AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING` contains the Commerce event provider ID.
 
+    - Update `<your_application_name>` as a prefix in both `events.config.yaml` and `app.config.yaml` to isolate [event providers](https://developer.adobe.com/commerce/extensibility/events/configure-additional-event-providers/) per application.
+
 1. The script requires the following environment variables, which update the values in **Stores > Configuration > Adobe Services > Adobe I/O Events > Commerce events**:
 
     - `COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID`: The merchant ID of the Commerce instance.
@@ -81,40 +83,6 @@ To configure eventing, follow these steps:
 
     - Update the `events_of_interest` field with the events that your app requires.
     - Update the `runtime_action` field with the action that will consume the events.
-
-1. To configure multiple Commerce event providers, update your configuration as follows:
-
-    -  In both `events.config.yaml` and `app.config.yaml`, set a unique prefix using your application name (lowercase, alphanumeric, underscores allowed). This prefix helps isolate event providers per extension.
-
-   **Example prefix usage:**
-      - `test_app.observer.sales_order_creditmemo_save_after`
-      - `testapp.observer.sales_order_creditmemo_save_after`
-      - `testapp123.observer.sales_order_creditmemo_save_after`
-
-      **Example:** `events.config.yaml`
-
-     ```yaml
-     label: Commerce events provider
-     subscription:
-       - event:
-           # Set the prefix to your application name (lowercase, alphanumeric, underscores allowed).
-           # This prefix must match the one used in app.config.yaml to ensure uniqueness across providers.
-           name: <your_application_name>.observer.sales_order_creditmemo_save_after
-           parent: observer.sales_order_creditmemo_save_after
-     ```
-
-      **Example:** `app.config.yaml`
-
-     ```yaml
-     Commerce events consumer:
-       description: Consumes events from Adobe Commerce
-       events_of_interest:
-         - provider_metadata: dx_commerce_events
-           event_codes:
-             # com.adobe.commerce.<your-application-name>.<commerce-event-code>
-             - com.adobe.commerce.<your-application-name>.observer.sales_order_creditmemo_save_after
-       runtime_action: commerce-checkout
-     ```
 
 This process must be completed before deploying the application for event registration.
 
@@ -143,8 +111,9 @@ The [`app.config.yaml`](https://github.com/adobe/commerce-checkout-starter-kit/b
         events_of_interest:
           - provider_metadata: dx_commerce_events
             event_codes:
+               # Set the prefix to your application name (lowercase, alphanumeric, underscores allowed).
                #com.adobe.commerce.<your-application-name>.<commerce-event-code>
-              - com.adobe.commerce.app_one.observer.sales_order_creditmemo_save_after
+              - com.adobe.commerce.checkout_starter_kit.observer.sales_order_creditmemo_save_after
         runtime_action: commerce-checkout-starter-kit/consume
 ```
 

--- a/src/pages/starter-kit/checkout/configure.md
+++ b/src/pages/starter-kit/checkout/configure.md
@@ -87,9 +87,9 @@ To configure eventing, follow these steps:
     -  In both `events.config.yaml` and `app.config.yaml`, set a unique prefix using your application name (lowercase, alphanumeric, underscores allowed). This prefix helps isolate event providers per extension.
 
    **Example prefix usage:**
-      - `test_app.observer.checkout_oope.sales_order_creditmemo_save_after`
-      - `testapp.observer.checkout_oope.sales_order_creditmemo_save_after`
-      - `testapp123.observer.checkout_oope.sales_order_creditmemo_save_after`
+      - `test_app.observer.sales_order_creditmemo_save_after`
+      - `testapp.observer.sales_order_creditmemo_save_after`
+      - `testapp123.observer.sales_order_creditmemo_save_after`
 
       **Example:** `events.config.yaml`
 
@@ -99,7 +99,7 @@ To configure eventing, follow these steps:
        - event:
            # Set the prefix to your application name (lowercase, alphanumeric, underscores allowed).
            # This prefix must match the one used in app.config.yaml to ensure uniqueness across providers.
-           name: <your_application_name>.observer.checkout_oope.sales_order_creditmemo_save_after
+           name: <your_application_name>.observer.sales_order_creditmemo_save_after
            parent: observer.sales_order_creditmemo_save_after
      ```
 
@@ -112,7 +112,7 @@ To configure eventing, follow these steps:
          - provider_metadata: dx_commerce_events
            event_codes:
              # com.adobe.commerce.<your-application-name>.<commerce-event-code>
-             - com.adobe.commerce.<your-application-name>.observer.checkout_oope sales_order_creditmemo_save_after
+             - com.adobe.commerce.<your-application-name>.observer.sales_order_creditmemo_save_after
        runtime_action: commerce-checkout
      ```
 
@@ -144,7 +144,7 @@ The [`app.config.yaml`](https://github.com/adobe/commerce-checkout-starter-kit/b
           - provider_metadata: dx_commerce_events
             event_codes:
                #com.adobe.commerce.<your-application-name>.<commerce-event-code>
-              - com.adobe.commerce.observer.sales_order_creditmemo_save_after
+              - com.adobe.commerce.app_one.observer.sales_order_creditmemo_save_after
         runtime_action: commerce-checkout-starter-kit/consume
 ```
 

--- a/src/pages/starter-kit/checkout/configure.md
+++ b/src/pages/starter-kit/checkout/configure.md
@@ -82,6 +82,40 @@ To configure eventing, follow these steps:
     - Update the `events_of_interest` field with the events that your app requires.
     - Update the `runtime_action` field with the action that will consume the events.
 
+1. To configure multiple Commerce event providers, update your configuration as follows:
+
+    -  In both `events.config.yaml` and `app.config.yaml`, set a unique prefix using your application name (lowercase, alphanumeric, underscores allowed). This prefix helps isolate event providers per extension.
+
+   **Example prefix usage:**
+      - `test_app.observer.checkout_oope.sales_order_creditmemo_save_after`
+      - `testapp.observer.checkout_oope.sales_order_creditmemo_save_after`
+      - `testapp123.observer.checkout_oope.sales_order_creditmemo_save_after`
+
+      **Example:** `events.config.yaml`
+
+     ```yaml
+     label: Commerce events provider
+     subscription:
+       - event:
+           # Set the prefix to your application name (lowercase, alphanumeric, underscores allowed).
+           # This prefix must match the one used in app.config.yaml to ensure uniqueness across providers.
+           name: <your_application_name>.observer.checkout_oope.sales_order_creditmemo_save_after
+           parent: observer.sales_order_creditmemo_save_after
+     ```
+
+      **Example:** `app.config.yaml`
+
+     ```yaml
+     Commerce events consumer:
+       description: Consumes events from Adobe Commerce
+       events_of_interest:
+         - provider_metadata: dx_commerce_events
+           event_codes:
+             # com.adobe.commerce.<your-application-name>.<commerce-event-code>
+             - com.adobe.commerce.<your-application-name>.observer.checkout_oope sales_order_creditmemo_save_after
+       runtime_action: commerce-checkout
+     ```
+
 This process must be completed before deploying the application for event registration.
 
 ### events.config.yaml
@@ -109,6 +143,7 @@ The [`app.config.yaml`](https://github.com/adobe/commerce-checkout-starter-kit/b
         events_of_interest:
           - provider_metadata: dx_commerce_events
             event_codes:
+               #com.adobe.commerce.<your-application-name>.<commerce-event-code>
               - com.adobe.commerce.observer.sales_order_creditmemo_save_after
         runtime_action: commerce-checkout-starter-kit/consume
 ```

--- a/src/pages/starter-kit/checkout/getting-started.md
+++ b/src/pages/starter-kit/checkout/getting-started.md
@@ -123,7 +123,9 @@ To install the individual modules, refer to the following topics:
 
 The [Commerce Eventing module](https://developer.adobe.com/commerce/extensibility/events/) is crucial for handling events within Adobe Commerce. The eventing module is installed automatically in Adobe Commerce version `2.4.6` and higher.
 
-This starter kit requires version `1.10.0` or higher of the Commerce Eventing module. To view your installed version, run the following command:
+This starter kit requires the **Commerce Eventing** module version `1.12.1` or higher, which introduces support for multi-event-provider functionality. It allows multiple App Builder extensions to connect to the same Adobe Commerce instance using isolated event providers.
+
+To view your installed version, run the following command:
 
 ```bash
 composer show magento/commerce-eventing


### PR DESCRIPTION
…tarter kit

## Purpose of this pull request

Updated doc to add multi event provider support in checkout starter kit
https://github.com/adobe/commerce-checkout-starter-kit/pull/46

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/getting-started/
- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/configure/#configure-eventing

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
