### PR TITLE
Correctly updates Admin UI SDK configuration page

### DIFF
--- a/src/pages/admin-ui-sdk/configuration.md
+++ b/src/pages/admin-ui-sdk/configuration.md
@@ -22,7 +22,6 @@ The [**Configure extensions**](./eligible-extensions-config.md) button allows yo
 
 The **Refresh registrations** button reloads all registrations from the App Builder registry. It is typically used when changes are made to the registration on the App Builder application side or when a new app is added and published, to reflect these changes in the Admin.
 
-By default, registrations are not refreshed. You can optionally set the **Refresh registrations on schedule** menu to refresh registrations daily, weekly, or monthly.  Weekly refreshes are performed on Sundays, while monthly refreshes are performed on the first day of the month.
 
 ## Database logging configuration
 


### PR DESCRIPTION
## Purpose of this pull request

Removes the "Refresh Registrations on Schedule" portion of the Admin UI SDK documentation so that it reflects accurately the current state of the Refresh Registrations feature, which no longer includes the ability to refresh registrations on schedule.

## Affected pages

https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/configuration/


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
