### PR TITLE
remove spaces from skus

### DIFF
--- a/src/pages/starter-kit/integration/webhooks.md
+++ b/src/pages/starter-kit/integration/webhooks.md
@@ -97,7 +97,7 @@ Follow admin configuration to modify your webhook and define the connection betw
     "items": [
       {
         "item_id": 1,
-        "sku": "Product SKU",
+        "sku": "Product-SKU",
         "qty": "Cart item qty"
       }
     ]

--- a/src/pages/webhooks/use-cases/product-price-update.md
+++ b/src/pages/webhooks/use-cases/product-price-update.md
@@ -34,7 +34,7 @@ The following `observer.sales_quote_item_set_product` default payload was obtain
       "entity_id": "11",
       "attribute_set_id": "4",
       "type_id": "simple",
-      "sku": "Simple product 3",
+      "sku": "Simple-product-3",
       ...
       "extension_attributes": {
         ...
@@ -49,13 +49,13 @@ The following `observer.sales_quote_item_set_product` default payload was obtain
         "entity_id": "11",
         "attribute_set_id": "4",
         "type_id": "simple",
-        "sku": "Simple product 3",
+        "sku": "Simple-product-3",
         "has_options": "0",
         ....
       },
       "product_id": "11",
       "product_type": "simple",
-      "sku": "Simple product 3",
+      "sku": "Simple-product-3",
       "name": "Simple product 3",
       "weight": "10.000000",
       "tax_class_id": "2",
@@ -72,7 +72,7 @@ The following `observer.sales_quote_item_set_product` default payload was obtain
 {
    "product": {
       "name": "Simple product 3",
-      "sku": "Simple product 3",
+      "sku": "Simple-product-3",
       "price": "10.000000"
     }
 }

--- a/src/pages/webhooks/use-cases/product-stock-validation.md
+++ b/src/pages/webhooks/use-cases/product-stock-validation.md
@@ -43,7 +43,7 @@ The following `observer.checkout_cart_product_add_before` default payload was ob
             "entity_id": "23",
             "attribute_set_id": "4",
             "type_id": "simple",
-            "sku": "Product 1",
+            "sku": "Product-1",
             "has_options": "0",
             "required_options": "0",
             "created_at": "2023-08-22 14:14:20",

--- a/src/pages/webhooks/use-cases/product-update-validation.md
+++ b/src/pages/webhooks/use-cases/product-update-validation.md
@@ -35,7 +35,7 @@ The following `observer.catalog_product_save_after` payload was obtained from ex
               "attribute_set_id": "16",
               "type_id": "simple",
               "sku": "Pr-1",
-              "name": "Product 1",
+              "name": "Product-1",
               "tax_class_id": "0",
               "description": "<p>Product 1 description</p>",
               "price": "10.00",
@@ -68,7 +68,7 @@ The following `observer.catalog_product_save_after` payload was obtained from ex
 ```json
 {
    "product": {
-        "name": "Product 1"
+        "name": "Product-1"
     }
 }
 ```


### PR DESCRIPTION
In conjunction with https://github.com/AdobeDocs/commerce-webapi/pull/488/files, this PR removes spaces from SKUs in example code, since they are causing issues in the integration starter kit.