### PR TITLE
Fix broken link to experience league checkout drop-in page

### DIFF
--- a/src/pages/starter-kit/checkout/eds.md
+++ b/src/pages/starter-kit/checkout/eds.md
@@ -15,7 +15,7 @@ Integrate your Out-of-Process Extensions (OOPE) with the Edge Delivery Service (
 The following prerequisites are required to enable your OOPE integration with the EDS Storefront:
 
 - [Integrate EDS Storefront with Adobe Commerce](https://experienceleague.adobe.com/developer/commerce/storefront/).
-- Configure Storefront in EDS with the [checkout drop-in component](https://experienceleague.adobe.com/developer/commerce/storefront/drop-ins/checkout/).
+- Configure Storefront in EDS with the [checkout drop-in component](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/).
   - The checkout drop-in component allows users to enter shipping and payment information, review their order details, and confirm their purchase.
   - To access the latest EDS Storefront boilerplate with drop-in components, see [EDS Adobe Commerce Boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a broken link to the experience league checkout drop-in page.
- The current link points to https://experienceleague.adobe.com/developer/commerce/storefront/drop-ins/checkout/
- It should point to https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/eds/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

N/A

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
