### PR TITLE
Add event size limitation to the event subscriptions in the Admin UI

### DIFF
--- a/src/_includes/event-size-limitation.md
+++ b/src/_includes/event-size-limitation.md
@@ -1,0 +1,3 @@
+<InlineAlert variant="warning" slots="text"/>
+
+Adobe recommends sending a limited number of fields per event. If you send all fields, you increase the risk of including sensitive or PCI compliance data in the event. In addition, specifying only the fields that are applicable to your business case is recommended for optimal performance and cost effectiveness. Including all fields might lead to larger payloads that exceed the size limit of 64 KB, and as a result, the event will not be created.

--- a/src/pages/events/create-events.md
+++ b/src/pages/events/create-events.md
@@ -10,6 +10,7 @@ edition: saas
 import SampleEvent from '/src/_includes/sample-event.md'
 import NestedEvent from '/src/_includes/nested-event.md'
 import ConditionalEvents from '/src/_includes/conditional-event.md'
+import EventSize from '/src/_includes/event-size-limitations.md'
 
 # Create event subscriptions from the Admin
 
@@ -44,6 +45,8 @@ Field | Description
 ### Configure event subscription fields
 
 The **Event Subscription Fields** configuration panel allows you to define the fields of the event payload to transmit from Commerce. The name provides the path to the field in the event payload.
+
+<EventSize />
 
 <SampleEvent />
 

--- a/src/pages/events/create-events.md
+++ b/src/pages/events/create-events.md
@@ -10,7 +10,7 @@ edition: saas
 import SampleEvent from '/src/_includes/sample-event.md'
 import NestedEvent from '/src/_includes/nested-event.md'
 import ConditionalEvents from '/src/_includes/conditional-event.md'
-import EventSize from '/src/_includes/event-size-limitations.md'
+import EventSize from '/src/_includes/event-size-limitation.md'
 
 # Create event subscriptions from the Admin
 

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -9,6 +9,7 @@ keywords:
 
 import SampleEvent from '/src/_includes/sample-event.md'
 import NestedEvent from '/src/_includes/nested-event.md'
+import EventSize from '/src/_includes/event-size-limitations.md'
 
 # Commerce module development
 
@@ -45,9 +46,7 @@ Create the `<module-root>/etc/io_events.xml` or `app/etc/io_events.xml` file and
 
 You can transmit all the fields within an event by setting the value of the `field` element to `*` (`<field name="*"  />`). You cannot use the `*` wildcard character to match partial strings.
 
-<InlineAlert variant="warning" slots="text"/>
-
-Adobe recommends sending a limited number of fields per event. If you send all fields, you increase the risk of including sensitive or PCI compliance data in the event. In addition, specifying only the fields that are applicable to your business case is recommended for optimal performance and cost effectiveness. Including all fields might lead to larger payloads that exceed the size limit of 64 KB, and as a result, the event will not be created.
+<EventSize />
 
 [Add custom fields to an event](custom-event-fields.md) describes how to enhance the payload of pre-defined events.
 

--- a/src/pages/events/module-development.md
+++ b/src/pages/events/module-development.md
@@ -9,7 +9,7 @@ keywords:
 
 import SampleEvent from '/src/_includes/sample-event.md'
 import NestedEvent from '/src/_includes/nested-event.md'
-import EventSize from '/src/_includes/event-size-limitations.md'
+import EventSize from '/src/_includes/event-size-limitation.md'
 
 # Commerce module development
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds an alert message about event size limitation to both PAAS and SaaS event subscription pages.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/create-events/
- https://developer.adobe.com/commerce/extensibility/events/module-development/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
