### PR TITLE
Fix field name in the webhook Exception operation

### DIFF
--- a/src/pages/webhooks/responses.md
+++ b/src/pages/webhooks/responses.md
@@ -47,7 +47,7 @@ The `exception` operation causes Commerce to terminate the process that triggere
 Field | Type | Description
 --- | --- | ---
 `op` | Required | Contains `exception`.
-`class` | Optional | Specifies the exception class. If `class` is not set, `\Magento\Framework\Exception\LocalizedException` will be thrown.
+`type` | Optional | Specifies the exception class. If `type` is not set, `\Magento\Framework\Exception\LocalizedException` will be thrown.
 `message` | Optional | Specifies the exception message. If this field is not explicitly set, then the message defined in the `fallbackErrorMessage` configuration field will be returned. If `fallbackErrorMessage` is not set, the system default error message will be returned.
 
 If an error occurs, the response is similar to the following:
@@ -55,7 +55,7 @@ If an error occurs, the response is similar to the following:
 ```json
 {
   "op": "exception",
-  "class": "Path\\To\\Exception\\Class",
+  "type": "Path\\To\\Exception\\Class",
   "message": "The product cannot be added to the cart because it is out of the stock"
 }
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes the field name to the correct one in the webhook Exception operation.

Reference to the code https://github.com/magento-commerce/commerce-webhooks/blob/main/AdobeCommerceWebhooks/Model/WebhookRunner/Response/Operation/Exception.php#L53

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/webhooks/responses/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
