### PR TITLE
Remove unsupported webhooks use cases from the left nav

### DIFF
--- a/src/data/navigation/sections/webhooks.js
+++ b/src/data/navigation/sections/webhooks.js
@@ -12,14 +12,6 @@ module.exports = [
             path: "/webhooks/use-cases/order-placement-validation.md"
           },
           {
-            title: "Checkout: Update product price",
-            path: "/webhooks/use-cases/product-price-update.md"
-          },
-          {
-            title: "Checkout: Validate product stock",
-            path: "/webhooks/use-cases/product-stock-validation.md"
-          },
-          {
             title: "Customer: Modify address",
             path: "/webhooks/use-cases/customer-address-modification.md"
           },


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes two unsupported webhooks use cases from the left nav. A subsequent PR will remove the files when the redirects have been put in place.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- src/data/navigation/sections/webhooks.js

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
