### PR TITLE
CEXT-6146: Correct documentation to reflect discount-only support in out-of-process totals collector

### DIFF
--- a/src/pages/starter-kit/checkout/totals-collector-development-considerations.md
+++ b/src/pages/starter-kit/checkout/totals-collector-development-considerations.md
@@ -8,7 +8,7 @@ keywords:
 
 # Totals collector development considerations
 
-When implementing out-of-process discount totals collector integrations, consider response model constraints, discount composition behavior, and failure handling. These considerations help keep totals collection predictable and checkout performance reliable.
+When implementing out-of-process discount totals collector integrations, consider response model constraints, discount composition behavior, and failure handling. These considerations help keep totals collection predictable and checkout performance reliable. Currently, the totals collector supports discount modifications only; support for additional total types may be added in the future.
 
 ## External discount engine
 
@@ -28,4 +28,4 @@ If your endpoint fails or times out, the webhook framework uses the configured `
 
 <InlineAlert variant="info" slots="text"/>
 
-The current implementation supports discount handling only via the DiscountHandler. Custom total types are not processed by this module.
+The current implementation supports discount handling only via the DiscountHandler. Any total types other than discounts are not supported at this time.

--- a/src/pages/starter-kit/checkout/totals-collector-development-considerations.md
+++ b/src/pages/starter-kit/checkout/totals-collector-development-considerations.md
@@ -8,7 +8,7 @@ keywords:
 
 # Totals collector development considerations
 
-When implementing out-of-process totals collector integrations, consider response model constraints, discount composition behavior, and failure handling. These considerations help keep totals collection predictable and checkout performance reliable.
+When implementing out-of-process discount totals collector integrations, consider response model constraints, discount composition behavior, and failure handling. These considerations help keep totals collection predictable and checkout performance reliable.
 
 ## External discount engine
 
@@ -25,3 +25,7 @@ The webhook supports a single `result` object per invocation. To model multiple 
 ## No discount (fallback)
 
 If your endpoint fails or times out, the webhook framework uses the configured `fallbackErrorMessage` and no out-of-process modifications are applied. Ensure your endpoint is fast and resilient so totals collection remains reliable.
+
+<InlineAlert variant="info" slots="text"/>
+
+The current implementation supports discount handling only via the DiscountHandler. Custom total types are not processed by this module.

--- a/src/pages/starter-kit/checkout/totals-collector-install.md
+++ b/src/pages/starter-kit/checkout/totals-collector-install.md
@@ -25,7 +25,7 @@ For more ideas on how you can use the totals collector module, refer to [totals 
 
 <Version />
 
-To enable out-of-process quote totals collection (for example, discounts from an external service) in Adobe Commerce, install the `magento/module-out-of-process-totals-collector` module using the following command:
+To enable out-of-process discount totals collection (from an external service) in Adobe Commerce, install the `magento/module-out-of-process-totals-collector` module using the following command:
 
 ```bash
 composer require magento/module-out-of-process-totals-collector --with-dependencies
@@ -36,5 +36,9 @@ composer require magento/module-out-of-process-totals-collector --with-dependenc
 <Configuration />
 
 After installation, register a webhook so that Adobe Commerce can call your App Builder application when quote totals are collected. The webhook runs after the core discount totals collector; your endpoint returns a JSON Patch response that is applied to the quote totals and items.
+
+<InlineAlert variant="info" slots="text"/>
+
+The totals collector currently supports discount modifications only. Other total types are not supported.
 
 For webhook registration details and payload/response format, see [totals collector use cases](./totals-collector-use-cases.md#totals-collector-webhook).

--- a/src/pages/starter-kit/checkout/totals-collector-use-cases.md
+++ b/src/pages/starter-kit/checkout/totals-collector-use-cases.md
@@ -8,17 +8,17 @@ keywords:
 
 # Totals collector use cases
 
-This page explores use cases and scenarios for implementing out-of-process quote totals (such as discounts) using the Adobe Commerce checkout starter kit and the `magento/module-out-of-process-totals-collector` module.
+This page explores use cases and scenarios for implementing out-of-process discount totals (such as discounts) using the Adobe Commerce checkout starter kit and the `magento/module-out-of-process-totals-collector` module.
 
 For more general use cases, refer to [use-cases](./use-cases.md).
 
 ## How it works
 
-The out-of-process totals collector extends Adobe Commerce quote totals collection with [webhooks](../../webhooks/index.md). When the core discount totals collector runs, a plugin invokes the `GetTotalModificationsInterface::execute` API. The webhook framework sends the quote and totals payload to your subscribed endpoint. Your App Builder application computes discounts (or other total modifications) and returns a JSON Patch response. Commerce applies the response to the quote totals and items, and the built-in `DiscountHandler` applies discount data so it appears in cart/checkout and in GraphQL.
+The out-of-process totals collector extends Adobe Commerce discount totals collection with [webhooks](../../webhooks/index.md). When the core discount totals collector runs, a plugin invokes the `GetTotalModificationsInterface::execute` API. The webhook framework sends the quote and totals payload to your subscribed endpoint. Your App Builder application computes discounts and returns a JSON Patch response. Commerce applies the response to the quote totals and items, and the built-in `DiscountHandler` applies discount data so it appears in cart/checkout and in GraphQL.
 
 ## Totals collector webhook
 
-To apply discounts (or other total modifications) from an external service, register a webhook for the method `plugin.magento.out_of_process_totals_collector.api.get_total_modifications.execute` (type `after`).
+To apply discounts from an external service, register a webhook for the method `plugin.magento.out_of_process_totals_collector.api.get_total_modifications.execute` (type `after`).
 
 &#8203;<Edition name="paas" /> To register the webhook, [modify the `webhooks.xml` file](../../webhooks/hooks.md) (in your module or in `app/etc`):
 
@@ -85,7 +85,7 @@ The request body includes the quote, shipping assignment, and current totals. Th
 }
 ```
 
-Your endpoint can use this data (items, quantities, prices, customer/quote attributes) to compute discounts or other modifications.
+Your endpoint can use this data (items, quantities, prices, customer/quote attributes) to compute discounts.
 
 ## Response format
 

--- a/src/pages/starter-kit/checkout/totals-collector-use-cases.md
+++ b/src/pages/starter-kit/checkout/totals-collector-use-cases.md
@@ -8,7 +8,7 @@ keywords:
 
 # Totals collector use cases
 
-This page explores use cases and scenarios for implementing out-of-process discount totals (such as discounts) using the Adobe Commerce checkout starter kit and the `magento/module-out-of-process-totals-collector` module.
+This page explores use cases and scenarios for implementing out-of-process discount totals using the Adobe Commerce checkout starter kit and the `magento/module-out-of-process-totals-collector` module.
 
 For more general use cases, refer to [use-cases](./use-cases.md).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request ipdates the document pages to reflect discount-only support in out-of-process totals collector

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/totals-collector-install/
- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/totals-collector-use-cases/
- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/totals-collector-development-considerations/

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
