### PR TITLE
Remove badge from journaling tutorial

### DIFF
--- a/src/pages/events/journaling-tutorial/index.md
+++ b/src/pages/events/journaling-tutorial/index.md
@@ -1,7 +1,6 @@
 ---
 title: Integrate events with Adobe I/O Events Journaling API
 description: Learn how to configure and build event-driven integrations between Adobe Commerce and Adobe App Builder using Journaling API.
-edition: saas
 keywords:
   - Extensibility
   - Events

--- a/src/pages/events/journaling-tutorial/registration-journaling-events.md
+++ b/src/pages/events/journaling-tutorial/registration-journaling-events.md
@@ -1,7 +1,6 @@
 ---
 title: Register and validate your journaling integration
 description: Learn how to configure and build event-driven integrations between Adobe Commerce and Adobe App Builder using Journaling API.
-edition: saas
 keywords:
   - Extensibility
   - Events

--- a/src/pages/events/journaling-tutorial/runtime-action-code-journaling-api.md
+++ b/src/pages/events/journaling-tutorial/runtime-action-code-journaling-api.md
@@ -1,7 +1,6 @@
 ---
 title: Code development and deployment
 description: Learn how to write, deploy, and manage runtime action code that processes events from Adobe Commerce using the Adobe I/O Events Journaling API.
-edition: saas
 keywords:
   - Extensibility
   - Events

--- a/src/pages/events/journaling-tutorial/validating-journaling-integration.md
+++ b/src/pages/events/journaling-tutorial/validating-journaling-integration.md
@@ -1,7 +1,6 @@
 ---
 title: Validate journaling events processing
 description: Learn how to validate that events from Adobe Commerce are successfully reaching the journaling endpoint and being processed by the runtime action.
-edition: saas
 keywords:
   - Extensibility
   - Events


### PR DESCRIPTION
## Purpose of this pull request

Removes the `edition: saas` frontmatter badge from the four pages in the journaling tutorial. The badge incorrectly implied the tutorial is limited to Adobe Commerce as a Cloud Service; the Journaling API integration it describes applies more broadly.

Ticket: CEXT-6178

## Affected pages

- https://developer.adobe.com/commerce/extensibility/events/journaling-tutorial
- https://developer.adobe.com/commerce/extensibility/events/journaling-tutorial/registration-journaling-events
- https://developer.adobe.com/commerce/extensibility/events/journaling-tutorial/runtime-action-code-journaling-api
- https://developer.adobe.com/commerce/extensibility/events/journaling-tutorial/validating-journaling-integration
