### PR TITLE
Create a landing page for the events tutorials

### DIFF
--- a/src/data/navigation/sections/events.js
+++ b/src/data/navigation/sections/events.js
@@ -5,7 +5,7 @@ module.exports = [
   },
   {
     title: "Tutorials",
-    path: "/events/tutorial/index.md",
+    path: "/events/tutorials.md",
     pages: [
       {
         title: "Eventing",

--- a/src/pages/events/journaling-tutorial/registration-journaling-events.md
+++ b/src/pages/events/journaling-tutorial/registration-journaling-events.md
@@ -14,10 +14,9 @@ In this section, you will register your Commerce events in the Adobe Developer C
 
 Before configuring journaling, ensure that you have completed the standard setup for Adobe Commerce Events and App Builder.
 
-- To create and configure an Event Provider in Adobe Commerce, follow the steps outlined in (Setting up Event Provider in Adobe Commerce) [https://developer.adobe.com/commerce/extensibility/events/tutorial/event-providers/#set-up-event-providers] up to the section
-**Sync event metadata with App Builder**
+- To create and configure an Event Provider in Adobe Commerce, follow the steps outlined in  [Setting up Event Provider in Adobe Commerce](../tutorial/event-providers.md#set-up-event-providers) up to the section **Sync event metadata with App Builder**.
 
-- To set up your App Builder project, follow the steps in (Set up the Adobe Developer Console and App Builder project locally) https://developer.adobe.com/commerce/extensibility/events/tutorial/deployment/#set-up-the-adobe-developer-console-and-app-builder-project-locally up to the section **Set up your local App Builder environment using the CLI**.
+- To set up your App Builder project, follow the steps in [Set up the Adobe Developer Console and App Builder project locally](../tutorial/deployment.md#set-up-the-adobe-developer-console-and-app-builder-project-locally) up to the section **Set up your local App Builder environment using the CLI**.
 
 ## Register Commerce events in Adobe Developer Console for Journaling
 
@@ -39,7 +38,7 @@ After registering Commerce events, you can verify that Adobe Commerce is success
 
 Follow these steps to validate event delivery:
 
-1. In your Adobe Commerce Admin panel, delete a product from the catalog. (**Catalog** > **Products** > **Delete Product**. This action triggers a product deletion event.
+1. In your Adobe Commerce Admin, delete a product from the catalog by navigating to **Catalog** > **Products** > **Delete Product**. This action triggers a product deletion event.
 
 1. Open the Adobe Developer Console and navigate to the event browser within your project workspace.
 

--- a/src/pages/events/tutorials.md
+++ b/src/pages/events/tutorials.md
@@ -1,0 +1,50 @@
+---
+title: Adobe Commerce Events Tutorials
+description: Learn how to build event-driven integrations between Adobe Commerce and Adobe App Builder using asynchronous events and the Adobe I/O Events Journaling API.
+keywords:
+  - Extensibility
+  - Events
+---
+
+# Events tutorials
+
+These tutorials walk you through building event-driven integrations between Adobe Commerce and Adobe App Builder. Each tutorial covers a distinct delivery model for Commerce events, so you can choose the approach that fits your use case.
+
+## Use events and App Builder to extend Adobe Commerce
+
+This tutorial covers the most direct event delivery model: a Commerce event triggers an Adobe I/O Events registration that immediately invokes an App Builder runtime action. A product update use case illustrates each step, from configuring an event provider and event metadata to writing and deploying the runtime action code.
+
+**What you learn:**
+
+- Set up an Adobe I/O event provider and event metadata in Adobe Commerce.
+- Create an event subscription and sync it with App Builder.
+- Initialize an App Builder project and write a runtime action that processes product events.
+- Register Commerce events in the Adobe Developer Console and verify end-to-end delivery.
+- Debug runtime actions locally using VS Code and the Adobe I/O CLI.
+
+**Applies to:** Adobe Commerce as a Cloud Service
+
+**Limitation:** Runtime actions invoked directly by an event registration must complete within 60 seconds. For long-running or blocking workloads, see the journaling tutorial below.
+
+[Start the tutorial](./tutorial/index.md)
+
+## Integrate Commerce events using the Adobe I/O Events Journaling API
+
+This tutorial covers journaling as an alternative to direct runtime invocation. Instead of immediately invoking a runtime action, Commerce events are stored in a journaling endpoint for up to seven days. A scheduled runtime action polls the journal, fetches batches of events, and processes them asynchronously. A product deletion use case illustrates the pattern.
+
+**What you learn:**
+
+- Register Commerce events in the Adobe Developer Console using the journaling delivery model.
+- Validate that events flow from Commerce to the journaling endpoint.
+- Write a runtime action that uses the Adobe I/O Events SDK to poll the journal, maintain a cursor in state storage, and process event payloads.
+- Validate that the runtime action correctly fetches and processes journaled events.
+
+**Applies to:** Adobe Commerce as a Cloud Service
+
+**When to use this approach:**
+
+- Your processing logic may exceed the 60-second runtime action limit.
+- You need to process events in bulk or at a controlled pace.
+- You want resilience against missed events, since the journal retains events for seven days.
+
+[Start the tutorial](./journaling-tutorial/index.md)

--- a/src/pages/events/tutorials.md
+++ b/src/pages/events/tutorials.md
@@ -12,6 +12,8 @@ These tutorials walk you through building event-driven integrations between Adob
 
 ## Use events and App Builder to extend Adobe Commerce
 
+&#8203;<Edition name="saas" />
+
 This tutorial covers the most direct event delivery model: a Commerce event triggers an Adobe I/O Events registration that immediately invokes an App Builder runtime action. A product update use case illustrates each step, from configuring an event provider and event metadata to writing and deploying the runtime action code.
 
 **In this tutorial, you will learn how to:**
@@ -22,15 +24,17 @@ This tutorial covers the most direct event delivery model: a Commerce event trig
 - Register Commerce events in the Adobe Developer Console and verify end-to-end delivery.
 - Debug runtime actions locally using VS Code and the Adobe I/O CLI.
 
-**Applies to:** Adobe Commerce as a Cloud Service
+<InlineAlert variant="info" slots="text"/>
 
-**Limitation:** Runtime actions invoked directly by an event registration must complete within 60 seconds. For long-running or blocking workloads, see the journaling tutorial below.
+Runtime actions invoked directly by an event registration must complete within 60 seconds. For long-running or blocking workloads, see the journaling tutorial below.
 
 [Start the tutorial](./tutorial/index.md)
 
 ## Integrate Commerce events using the Adobe I/O Events Journaling API
 
-This tutorial covers journaling as an alternative to direct runtime invocation. Instead of immediately invoking a runtime action, Commerce events are stored in a journaling endpoint for up to seven days. A scheduled runtime action polls the journal, fetches batches of events, and processes them asynchronously.
+The journaling tutorial covers journaling as an alternative to direct runtime invocation. Instead of immediately invoking a runtime action, Commerce events are stored in a journaling endpoint for up to seven days. A scheduled runtime action polls the journal, fetches batches of events, and processes them asynchronously.
+
+This tutorial is appliable to all versions of Adobe Commerce.
 
 **In this tutorial you will learn how to:**
 
@@ -38,8 +42,6 @@ This tutorial covers journaling as an alternative to direct runtime invocation. 
 - Validate that events flow from Commerce to the journaling endpoint.
 - Write a runtime action that uses the Adobe I/O Events SDK to poll the journal, maintain a cursor in state storage, and process event payloads.
 - Validate that the runtime action correctly fetches and processes journaled events.
-
-**Applies to:** Adobe Commerce as a Cloud Service
 
 **When to use this approach:**
 

--- a/src/pages/events/tutorials.md
+++ b/src/pages/events/tutorials.md
@@ -14,7 +14,7 @@ These tutorials walk you through building event-driven integrations between Adob
 
 This tutorial covers the most direct event delivery model: a Commerce event triggers an Adobe I/O Events registration that immediately invokes an App Builder runtime action. A product update use case illustrates each step, from configuring an event provider and event metadata to writing and deploying the runtime action code.
 
-**What you learn:**
+**In this tutorial, you will learn how to:**
 
 - Set up an Adobe I/O event provider and event metadata in Adobe Commerce.
 - Create an event subscription and sync it with App Builder.
@@ -30,9 +30,9 @@ This tutorial covers the most direct event delivery model: a Commerce event trig
 
 ## Integrate Commerce events using the Adobe I/O Events Journaling API
 
-This tutorial covers journaling as an alternative to direct runtime invocation. Instead of immediately invoking a runtime action, Commerce events are stored in a journaling endpoint for up to seven days. A scheduled runtime action polls the journal, fetches batches of events, and processes them asynchronously. A product deletion use case illustrates the pattern.
+This tutorial covers journaling as an alternative to direct runtime invocation. Instead of immediately invoking a runtime action, Commerce events are stored in a journaling endpoint for up to seven days. A scheduled runtime action polls the journal, fetches batches of events, and processes them asynchronously.
 
-**What you learn:**
+**In this tutorial you will learn how to:**
 
 - Register Commerce events in the Adobe Developer Console using the journaling delivery model.
 - Validate that events flow from Commerce to the journaling endpoint.


### PR DESCRIPTION
## Purpose of this pull request

Adds a tutorials landing page for the Events section. Previously, the "Tutorials" nav entry pointed directly into the first tutorial, leaving readers with no overview of the two available tutorials or guidance on which to choose.
The new page summarizes both the eventing tutorial (direct runtime action invocation) and the journaling tutorial (asynchronous event polling), describes what each covers, and calls out the 60-second runtime limit as the key decision point between the two approaches. The nav entry for "Tutorials" is updated to point to the new landing page.

This page is necessary the Eventing tutorial landing page was used in 3 consecutive links in the left nav,  and that interfered with navigating to the journaling tutorial.

This PR also cleans up some malformed links.

Ticket: CEXT-6178

## Affected pages
- https://developer.adobe.com/commerce/extensibility/events/tutorials
- https://developer.adobe.com/commerce/extensibility/events/journaling-tutorial/registration-journaling-events/

### What's New highlights

whatsnew
Added an [Events tutorials](https://developer.adobe.com/commerce/extensibility/events/tutorials) landing page that summarizes both the eventing and journaling tutorials and helps developers choose the right event delivery model for their use case.
