### PR TITLE
Added feedback after partner event

### DIFF
--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -88,10 +88,6 @@ The following field types are available for your `businessConfig` schema:
 | `url` | string | URL input with validation |
 | `list` | string | Dropdown with preconfigured options |
 
-### Commerce environment fields
-
-Optional property `env` is an array of **`"paas"`**, **`"saas"`**, or both. App Management shows the field only for the environments you list. When `env` is omitted, the field applies to every Commerce environment. This matches the configuration library behavior for [conditional fields by Commerce environment](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#conditional-fields-by-commerce-environment).
-
 ### Password field encryption
 
 Password fields are automatically encrypted using `AES-256-GCM` when stored and decrypted when retrieved.

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -12,7 +12,7 @@ keywords:
 
 Based on the `businessConfig` schema that you defined in the `app.commerce.config`, the configuration library generates the runtime actions that the App Management UI uses to render a configuration form with no custom code required.
 
-See [Initialize your app](initialize-app.md) for setup instructions and [Build and deploy](build-deploy.md) for information about generated runtime actions and project structure.
+See [Initialize your app](./initialize-app.md) for setup instructions and [Build and deploy](./build-deploy.md) for information about generated runtime actions and project structure.
 
 ## Example
 
@@ -73,7 +73,7 @@ This `businessConfig` schema contains the following properties:
 | `description` | string | No | Help text displayed below the field. |
 | `options` | array | Conditional | Required for `list`. Defines available options to be displayed in the dropdown list. |
 | `selectionMode` | string | Conditional | Required for `list`. Set to `single` for standard dropdown or `multiple` to allow multiple selections. |
-| `env` | array | No | Restricts the field to one or more Commerce environments. When omitted, the field applies to all environments. See [Commerce environment fields](#commerce-environment-fields). |
+| `env` | array | No | Limits the field to **PaaS** (`"paas"`), **SaaS** (`"saas"`), or both. When omitted, the field applies to all environments. See [Commerce environment fields](#commerce-environment-fields). |
 
 ## Supported field types
 
@@ -90,7 +90,7 @@ The following field types are available for your `businessConfig` schema:
 
 ### Commerce environment fields
 
-Each schema field can include an optional `env` array so App Management shows it only for each environment, or a combination of both. When `env` is omitted, the field applies to every Commerce environment. This matches how the configuration library interprets the [schema](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#conditional-fields-by-commerce-environment).
+Optional property `env` is an array of **`"paas"`**, **`"saas"`**, or both. App Management shows the field only for the environments you list. When `env` is omitted, the field applies to every Commerce environment. This matches the configuration library behavior for [conditional fields by Commerce environment](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#conditional-fields-by-commerce-environment).
 
 ### Password field encryption
 
@@ -162,7 +162,7 @@ Never commit the `.env` file to version control. Keep the encryption key secure 
 
 See [Password Field Encryption](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/password-encryption.md) for more information.
 
-See [Failed to decrypt configuration](troubleshooting.md#failed-to-decrypt-configuration-re-association-or-configuration-page) if you already see decrypt errors.
+See [Failed to decrypt configuration](./troubleshooting.md#failed-to-decrypt-configuration-re-association-or-configuration-page) if you already see decrypt errors.
 
 ### Multiple selection list fields
 
@@ -211,11 +211,15 @@ Your `app.commerce.config` is validated each time you run a `generate` command (
 
 Use `getConfigurationByKey` from the configuration library (together with `getConfiguration` and `setConfiguration` when you need full documents or writes) to access configuration values in your runtime actions.
 
-You must call `initialize` with your generated configuration schema before any of those functions. The schema is held in memory for the lifetime of the action invocation. You can load it from the generated `configuration-schema.json` under your `commerce/configuration/1`. See [Initialization](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#initialization) in the configuration library usage guide for more information.
+Before you run `getConfiguration`, `getConfigurationByKey`, or `setConfiguration`, call `initialize` with your generated configuration schema. The schema is kept in memory for that action invocation. Import the generated `configuration-schema.json` from your `commerce/configuration/1` extension (the path relative to your action depends on your project layout).
+
+If you skip `initialize`, see [Initialization](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#initialization) in the configuration library usage guide for more information.
 
 A **scope selector** tells the library which node in the scope tree to read or write. That tree can include **Adobe Commerce** scopes (such as websites and store views, each with a scope code and a **level** in the hierarchy), **custom scopes** you create in App Management (code only; see below), **global** scope, and other nodes that your app or merchants configure.
 
-When the target scope has **both** a code and a level—typical for Commerce store and website scopes—use `byCodeAndLevel`:
+When the target scope has both a code and a level—typical for Commerce store and website scopes—use `byCodeAndLevel`.
+
+The following examples show only the configuration calls. In your action, run `initialize` before these calls, as described in the opening paragraphs of this section. For a full runtime action example, see [Using configuration in runtime actions](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#using-configuration-in-runtime-actions) in the usage guide.
 
 ```js
 import { getConfigurationByKey, byCodeAndLevel } from "@adobe/aio-commerce-lib-config";

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -73,7 +73,7 @@ This `businessConfig` schema contains the following properties:
 | `description` | string | No | Help text displayed below the field. |
 | `options` | array | Conditional | Required for `list`. Defines available options to be displayed in the dropdown list. |
 | `selectionMode` | string | Conditional | Required for `list`. Set to `single` for standard dropdown or `multiple` to allow multiple selections. |
-| `env` | array | No | Limits the field to **PaaS** (`paas`) or **SaaS** (`saas`). To enable the field to all environments, omit the field or specify both values. See [Commerce environment fields](#commerce-environment-fields). |
+| `env` | array | No | Limits the field to **PaaS** (`paas`) or **SaaS** (`saas`). To enable the field to all environments, omit the field or specify both values. |
 
 ## Supported field types
 

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -73,7 +73,7 @@ This `businessConfig` schema contains the following properties:
 | `description` | string | No | Help text displayed below the field. |
 | `options` | array | Conditional | Required for `list`. Defines available options to be displayed in the dropdown list. |
 | `selectionMode` | string | Conditional | Required for `list`. Set to `single` for standard dropdown or `multiple` to allow multiple selections. |
-| `env` | array | No | Limits the field to **PaaS** (`"paas"`), **SaaS** (`"saas"`), or both. When omitted, the field applies to all environments. See [Commerce environment fields](#commerce-environment-fields). |
+| `env` | array | No | Limits the field to **PaaS** (`paas`) or **SaaS** (`saas`). To enable the field to all environments, omit the field or specify both values. See [Commerce environment fields](#commerce-environment-fields). |
 
 ## Supported field types
 
@@ -217,7 +217,7 @@ If you skip `initialize`, see [Initialization](https://github.com/adobe/aio-comm
 
 A **scope selector** tells the library which node in the scope tree to read or write. That tree can include **Adobe Commerce** scopes (such as websites and store views, each with a scope code and a **level** in the hierarchy), **custom scopes** you create in App Management (code only; see below), **global** scope, and other nodes that your app or merchants configure.
 
-When the target scope has both a code and a level—typical for Commerce store and website scopes—use `byCodeAndLevel`.
+When the target scope has both a code and a level, which is typical for Commerce store and website scopes, use `byCodeAndLevel`.
 
 The following examples show only the configuration calls. In your action, run `initialize` before these calls, as described in the opening paragraphs of this section. For a full runtime action example, see [Using configuration in runtime actions](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#using-configuration-in-runtime-actions) in the usage guide.
 

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -73,6 +73,7 @@ This `businessConfig` schema contains the following properties:
 | `description` | string | No | Help text displayed below the field. |
 | `options` | array | Conditional | Required for `list`. Defines available options to be displayed in the dropdown list. |
 | `selectionMode` | string | Conditional | Required for `list`. Set to `single` for standard dropdown or `multiple` to allow multiple selections. |
+| `env` | array | No | Restricts the field to one or more Commerce environments. When omitted, the field applies to all environments. See [Commerce environment fields](#commerce-environment-fields). |
 
 ## Supported field types
 
@@ -86,6 +87,10 @@ The following field types are available for your `businessConfig` schema:
 | `tel` | string | Phone number input with format validation |
 | `url` | string | URL input with validation |
 | `list` | string | Dropdown with preconfigured options |
+
+### Commerce environment fields
+
+Each schema field can include an optional `env` array so App Management shows it only for each environment, or a combination of both. When `env` is omitted, the field applies to every Commerce environment. This matches how the configuration library interprets the [schema](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#conditional-fields-by-commerce-environment).
 
 ### Password field encryption
 
@@ -206,6 +211,8 @@ Your `app.commerce.config` is validated each time you run a `generate` command (
 
 Use `getConfigurationByKey` from the configuration library (together with `getConfiguration` and `setConfiguration` when you need full documents or writes) to access configuration values in your runtime actions.
 
+You must call `initialize` with your generated configuration schema before any of those functions. The schema is held in memory for the lifetime of the action invocation. You can load it from the generated `configuration-schema.json` under your `commerce/configuration/1`. See [Initialization](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#initialization) in the configuration library usage guide for more information.
+
 A **scope selector** tells the library which node in the scope tree to read or write. That tree can include **Adobe Commerce** scopes (such as websites and store views, each with a scope code and a **level** in the hierarchy), **custom scopes** you create in App Management (code only; see below), **global** scope, and other nodes that your app or merchants configure.
 
 When the target scope has **both** a code and a level—typical for Commerce store and website scopes—use `byCodeAndLevel`:
@@ -225,7 +232,7 @@ async function main(params) {
 }
 ```
 
-**Custom scopes** created in the App Management UI are identified by **code only**; they do not define a separate **level** in the tree. For those scopes you must use **`byCode("your-custom-scope-code")`**. `byCodeAndLevel` is not used for custom scopes because there is no level to pass.
+**Custom scopes** created in the App Management UI are identified by **code only**. They do not define a separate **level** in the tree. For those scopes you must use **`byCode("your-custom-scope-code")`**. `byCodeAndLevel` is not used for custom scopes because there is no level to pass. See the configuration library [usage](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md) for more information.
 
 ```js
 import { getConfigurationByKey, byCode } from "@adobe/aio-commerce-lib-config";

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -215,7 +215,7 @@ A **scope selector** tells the library which node in the scope tree to read or w
 
 When the target scope has both a code and a level, which is typical for Commerce store and website scopes, use `byCodeAndLevel`.
 
-The following examples show only the configuration calls. In your action, run `initialize` before these calls, as described in the opening paragraphs of this section. For a full runtime action example, see [Using configuration in runtime actions](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#using-configuration-in-runtime-actions) in the usage guide.
+The following examples show only the configuration calls. In your action, run `initialize` before these calls. For a full runtime action example, see [Using configuration in runtime actions](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#using-configuration-in-runtime-actions) in the usage guide.
 
 ```js
 import { getConfigurationByKey, byCodeAndLevel } from "@adobe/aio-commerce-lib-config";

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -10,18 +10,18 @@ keywords:
 
 # Webhooks
 
-The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce Webhook](https://developer.adobe.com/commerce/extensibility/webhooks/) subscriptions for your application. App Management uses that definition during installation to provision the subscriptions your app needs, similar to how [Events](events.md) subscriptions are driven from your configuration so merchants get an out-of-the-box experience instead of assembling webhook setup themselves. Webhooks allow your app to respond to live Commerce processes, such as checkout, or cart validation.
+The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce Webhook](https://developer.adobe.com/commerce/extensibility/webhooks/) subscriptions for your application. App Management uses that definition during installation to provision the subscriptions your app needs, similar to how [Events](./events.md) subscriptions are driven from your configuration so merchants get an out-of-the-box experience instead of assembling webhook setup themselves. Webhooks allow your app to respond to live Commerce processes, such as checkout, or cart validation.
 
 ## Responsibilities by role
 
 Webhook configuration spans both the developer who ships the app and the merchant who associates it with Commerce:
 
 * **App developers** declare webhooks in the `webhooks` field of `app.commerce.config`. That manifest is what App Management uses to know which webhook subscriptions belong to your app.
-* **Merchants** get webhooks driven from that manifest for an out-of-the-box experience in many cases. If Commerce or your app needs extra connection steps (for example edition-specific setup), follow [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) on Experience League.
+* **Merchants** usually get webhooks from that manifest without extra setup. If **Adobe Commerce** or your app still needs more steps, see [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) (Experience League) — user guides in the Adobe Commerce Help site.
 
 ### Use Events and webhooks together
 
-Use [Events](events.md) and webhooks when you need both asynchronous event delivery and synchronous hooks inside Commerce processes.
+Use [Events](./events.md) and webhooks when you need both asynchronous event delivery and synchronous hooks inside Commerce processes.
 
 ## Webhook entries
 

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -10,7 +10,9 @@ keywords:
 
 # Webhooks
 
-The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce webhook](https://developer.adobe.com/commerce/extensibility/webhooks/) subscriptions for your application and configures the subscriptions on the merchant's Admin. Webhooks allow your app to make calls to third-party systems synchronously.
+The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce webhook](../../webhooks/index.md) subscriptions for your application and configures the subscriptions on the merchant's Admin. Webhooks allow your app to make calls to third-party systems synchronously.
+
+Use [Events](./events.md) and webhooks when you need both asynchronous event delivery and synchronous hooks inside Commerce processes.
 
 ## Responsibilities by role
 
@@ -18,10 +20,6 @@ Webhook configuration spans both the developer who ships the app and the merchan
 
 * **App developers** declare webhooks in the `webhooks` field of `app.commerce.config`. That manifest is what App Management uses to know which webhook subscriptions belong to your app.
 * **Merchants** usually get webhooks from that manifest without extra setup. If **Adobe Commerce** or your app still needs more steps, see [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) (Experience League) — user guides in the Adobe Commerce Help site.
-
-### Use Events and webhooks together
-
-Use [Events](./events.md) and webhooks when you need both asynchronous event delivery and synchronous hooks inside Commerce processes.
 
 ## Webhook entries
 

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -17,7 +17,7 @@ The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce
 Webhook configuration spans both the developer who ships the app and the merchant who associates it with Commerce:
 
 * **App developers** declare webhooks in the `webhooks` field of `app.commerce.config`. That manifest is what App Management uses to know which webhook subscriptions belong to your app.
-* **Merchants** receive an out-of-the-box experience with webhooks. See [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) for more information.
+* **Merchants** get webhooks driven from that manifest for an out-of-the-box experience in many cases. If Commerce or your app needs extra connection steps (for example edition-specific setup), follow [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) on Experience League.
 
 ### Use Events and webhooks together
 

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -10,7 +10,7 @@ keywords:
 
 # Webhooks
 
-The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce webhook](../../webhooks/index.md) subscriptions for your application and configures the subscriptions on the merchant's Admin. Webhooks allow your app to make calls to third-party systems synchronously.
+The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce webhook](../../webhooks/index.md) subscriptions for your application and configures the subscriptions in the merchant's Admin. Webhooks allow your app to make calls to third-party systems synchronously.
 
 Use [Events](./events.md) and webhooks when you need both asynchronous event delivery and synchronous hooks inside Commerce processes.
 
@@ -19,7 +19,7 @@ Use [Events](./events.md) and webhooks when you need both asynchronous event del
 Webhook configuration spans both the developer who ships the app and the merchant who associates it with Commerce:
 
 * **App developers** declare webhooks in the `webhooks` field of `app.commerce.config`. That manifest is what App Management uses to know which webhook subscriptions belong to your app.
-* **Merchants** usually get webhooks from that manifest without extra setup. If **Adobe Commerce** or your app still needs more steps, see [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) (Experience League) — user guides in the Adobe Commerce Help site.
+* **Merchants** usually get webhooks from that manifest without extra setup. See [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps)  for more information on how to configure Adobe Commerce.
 
 ## Webhook entries
 

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -10,7 +10,7 @@ keywords:
 
 # Webhooks
 
-The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce Webhook](https://developer.adobe.com/commerce/extensibility/webhooks/) subscriptions for your application. App Management uses that definition during installation to provision the subscriptions your app needs, similar to how [Events](./events.md) subscriptions are driven from your configuration so merchants get an out-of-the-box experience instead of assembling webhook setup themselves. Webhooks allow your app to respond to live Commerce processes, such as checkout, or cart validation.
+The `webhooks` field in your `app.commerce.config` file declares [Adobe Commerce webhook](https://developer.adobe.com/commerce/extensibility/webhooks/) subscriptions for your application and configures the subscriptions on the merchant's Admin. Webhooks allow your app to make calls to third-party systems synchronously.
 
 ## Responsibilities by role
 


### PR DESCRIPTION
## Purpose of this pull request

This PR updates our App Management docs from feedback received during an **Adobe Commerce Partner Acceleration (Barcelona, May 2026)** event.

## Affected pages

- [Business configuration](https://developer.adobe.com/commerce/extensibility/app-management/configuration-schema/)
- [Webhooks](https://developer.adobe.com/commerce/extensibility/app-management/installation/webhooks/)

whatsnew
Adds business configuration optional `env` field, and links to **aio-commerce-lib-config** usage page. Also, clarifies custom scopes and merchant webhook OOTB wording.