### PR TITLE
Add links to Community Slack channel

### DIFF
--- a/src/pages/app-development/learning-path.md
+++ b/src/pages/app-development/learning-path.md
@@ -70,3 +70,4 @@ The following resources will help you get to know the extensibility options offe
 - [Logging and troubleshooting in App Builder](best-practices/logging-troubleshooting.md)
 - [Adobe I/O Events frequently asked questions](https://developer.adobe.com/events/docs/support/faq)
 - [App Builder security overview](https://developer.adobe.com/app-builder/docs/guides/app_builder_guides/security/)
+- [`#app-builder-community` Slack channel](https://magentocommeng.slack.com/archives/C04KT43Q75K)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -86,6 +86,10 @@ Is a complete framework that enables enterprise developers to build and deploy c
 
 Allows developers to integrate private and third-party APIs and other software interfaces with Adobe Commerce and other Adobe products using Adobe IO.
 
+## Join the conversation
+
+Join the [#app-builder-community](https://magentocommeng.slack.com/archives/C04KT43Q75K) Slack channel to ask questions, share your work, and connect with other developers interested in Adobe Commerce extensibility and App Builder.
+
 ## Contributing to this documentation
 
 We encourage you to participate in our open documentation initiative. If you have suggestions, corrections, additions, or deletions for this documentation, check out the source on [GitHub](https://github.com/AdobeDocs/commerce-extensibility), and open a pull request.


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds links to the `#app-builder-community` Slack channel so developers can connect with the community while working through the extensibility documentation. It:
- Adds a **Join the conversation** section to the Commerce extensibility landing page with a link to the Slack channel.
- Adds the Slack channel to the resources list on the App Builder **Learning path** page.
- 
## Affected pages
- https://developer.adobe.com/commerce/extensibility
- https://developer.adobe.com/commerce/extensibility/app-development/learning-path

### What's New highlights

whatsnew
Added links to the [#app-builder-community](https://magentocommeng.slack.com/archives/C04KT43Q75K) Slack channel on the [Commerce extensibility overview](https://developer.adobe.com/commerce/extensibility) and the [App Builder learning path](https://developer.adobe.com/commerce/extensibility/app-development/learning-path), so developers can ask questions and connect with the community.