### PR TITLE
fix: update workflow reference for project board integration

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -12,5 +12,5 @@ on:
 
 jobs:
   call-workflow-add-to-project:
-    uses: AdobeDocs/commerce-php/.github/workflows/add-to-project_job.yml@main
+    uses: AdobeDocs/commerce-contributor/.github/workflows/add-to-project_job.yml@main
     secrets: inherit


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes reference to the reusable GitHub workflow for _Add pull requests and issues to projects_.
