### PR TITLE
chore: update GraphQL documentation links in package.json and tax-reference.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
       "https://cline.bot/",
       "https://developer.adobe.com/app-builder/docs/guides/app_builder_guides/development#debugging",
       "https://developer.adobe.com/app-builder/docs/guides/runtime_guides/tools/cli-install",
-      "https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-Cart",
-      "https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CartPrices",
       "https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/cart/",
       "https://developer.adobe.com/events/docs/api#operation/createProvider",
       "https://developer.adobe.com/events/docs/api#operation/createProvider",

--- a/src/pages/starter-kit/checkout/tax-reference.md
+++ b/src/pages/starter-kit/checkout/tax-reference.md
@@ -259,7 +259,7 @@ The following are GraphQL query examples to check the taxes applied by the tax i
 
 ### Cart taxes
 
-To check the taxes applied to the cart, you can use the [`getCart`](https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/cart/) query to retrieve the [`cart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-Cart)/[`prices`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CartPrices)/[`applied_taxes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CartPrices) field. This field contains information about the taxes applied to the cart.
+To check the taxes applied to the cart, you can use the [`getCart`](https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/cart/) query to retrieve the [`cart`](https://developer.adobe.com/commerce/webapi/reference/graphql/latest/types-c-e#cart)/[`prices`](https://developer.adobe.com/commerce/webapi/reference/graphql/latest/types-c-e#cartprices)/[`applied_taxes`](https://developer.adobe.com/commerce/webapi/reference/graphql/latest/types-c-e#cartprices) field. This field contains information about the taxes applied to the cart.
 
 <InlineAlert variant="info" slots="text"/>
 


### PR DESCRIPTION
## Purpose of this pull request

Updates outdated GraphQL API reference links in the tax reference documentation and removes the corresponding stale link-check entries from `package.json`. The old URLs pointed to the deprecated `graphql-api/index.html#definition-*` anchor format; they now point to the current `reference/graphql/latest/types-c-e#*` path.

## Affected pages

- https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/tax-reference/
