### PR TITLE
USF-4113: document dropins MCP server and storefront skills for AEM Boilerplate Commerce

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -187,7 +187,7 @@
     - AI coding tooling header
     - [Overview](/developer-agent/index.md)
     - [Coding tools setup](/developer-agent/coding-tools.md)
-    - [dropins MCP server](/developer-agent/dropins-mcp-server.md)
+    - [Dropins MCP server](/developer-agent/dropins-mcp-server.md)
     - [Skills, prompts, and commands](/developer-agent/skills-and-prompts.md)
     - [Use cases](/developer-agent/use-cases.md)
     - [Best practices](/developer-agent/best-practices.md)

--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -187,6 +187,7 @@
     - AI coding tooling header
     - [Overview](/developer-agent/index.md)
     - [Coding tools setup](/developer-agent/coding-tools.md)
+    - [dropins MCP server](/developer-agent/dropins-mcp-server.md)
     - [Skills, prompts, and commands](/developer-agent/skills-and-prompts.md)
     - [Use cases](/developer-agent/use-cases.md)
     - [Best practices](/developer-agent/best-practices.md)

--- a/src/pages/developer-agent/coding-tools.md
+++ b/src/pages/developer-agent/coding-tools.md
@@ -85,7 +85,7 @@ Run the following command and follow the interactive prompts:
 aio commerce extensibility app-setup
 ```
 
-After the command completes, navigate to your project directory and restart your coding agent to load the new MCP tools and skills. If your tutorial requires a storefront, rerun the command and select the AEM Boilerplate Commerce starter kit.
+After the command completes, navigate to your project directory and restart your coding agent to load the new MCP tools and skills. If your tutorial requires a storefront, rerun the command and select the AEM Boilerplate Commerce starter kit. This additionally installs the [`dropins` MCP server](dropins-mcp-server.md) and storefront agent skills.
 
 The following example installation shows the interactive prompts and output for the checkout starter kit.
 
@@ -230,7 +230,7 @@ Next steps:
          AEM Boilerplate Commerce
       ```
 
-      **Note:** Selecting **AEM Boilerplate Commerce** additionally installs and configures the [`dropins` MCP server](#dropins-mcp-server-for-storefront-development) and storefront agent skills in addition to the `commerce-extensibility` MCP server.
+      **Note:** Selecting **AEM Boilerplate Commerce** additionally installs and configures the [`dropins` MCP server](dropins-mcp-server.md) and storefront agent skills in addition to the `commerce-extensibility` MCP server.
 
    * Select your preferred coding agent. Over 40 coding agents are supported; if you do not see your preferred agent, use the `Other` option to install skills for any coding agent. Refer to your coding agent's documentation for how to configure skills.
 
@@ -266,26 +266,7 @@ Next steps:
 
 Before deploying your project, complete configuration tasks: log in to [Adobe Developer Console](https://developer.adobe.com/console) using the Adobe I/O CLI, create an App Builder project (see [Project setup](../events/project-setup.md)), and set up environment variables in an `.env` file. You can do these steps manually or use the AI coding tools for guidance. See [Create an integration](../starter-kit/integration/create-integration.md) for detailed configuration instructions.
 
-## `dropins` MCP server for storefront development
-
-If you select `AEM Boilerplate Commerce` in the `aio commerce extensibility tools-setup` command, the [`@dropins/mcp`](https://www.npmjs.com/package/@dropins/mcp) server and a set of storefront-specific agent skills are installed in addition to the standard `commerce-extensibility` MCP server and App Builder skills.
-
-The `dropins` MCP server provides structured, authoritative data about every drop-in component extracted directly from the drop-in source repositories. Agent skills use this server as the primary reference for storefront customization tasks, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
-
-If you select `AEM Boilerplate Commerce` in the `aio commerce extensibility tools-setup` command, the tool:
-
-* Installs `@dropins/mcp` globally (`npm install -g @dropins/mcp@latest`), so the latest version is available immediately.
-* Configures your coding agent to run the server with `npx --yes @dropins/mcp`, so it starts automatically without prompting.
-
-For the list of storefront skills and the `dropins` MCP tools they use, see [Storefront skills](skills-and-prompts.md#storefront-skills).
-
-### Updating the `dropins` MCP server
-
-The server checks npm on startup and prints a warning to `stderr` if a newer stable version is available. To update manually run the following command:
-
-```bash
-npm update -g @dropins/mcp
-```
+If you selected the AEM Boilerplate Commerce starter kit, see [`dropins` MCP server for storefront development](dropins-mcp-server.md) for details on the additional server and skills that were installed.
 
 ## Post-installation configuration
 

--- a/src/pages/developer-agent/coding-tools.md
+++ b/src/pages/developer-agent/coding-tools.md
@@ -230,7 +230,7 @@ Next steps:
          AEM Boilerplate Commerce
       ```
 
-      **Note:** Selecting **AEM Boilerplate Commerce** additionally installs and configures the [`dropins` MCP server](#dropins-mcp-server-for-storefront-development) and storefront-specific agent skills, alongside the `commerce-extensibility` MCP server.
+      **Note:** Selecting **AEM Boilerplate Commerce** additionally installs and configures the [`dropins` MCP server](#dropins-mcp-server-for-storefront-development) and storefront agent skills in addition to the `commerce-extensibility` MCP server.
 
    * Select your preferred coding agent. Over 40 coding agents are supported; if you do not see your preferred agent, use the `Other` option to install skills for any coding agent. Refer to your coding agent's documentation for how to configure skills.
 
@@ -262,30 +262,30 @@ Next steps:
 
    Skills and MCP tools are installed. If you do not see them, restart your coding agent.
 
+<InlineAlert variant="info" slots="text" />
+
+Before deploying your project, complete configuration tasks: log in to [Adobe Developer Console](https://developer.adobe.com/console) using the Adobe I/O CLI, create an App Builder project (see [Project setup](../events/project-setup.md)), and set up environment variables in an `.env` file. You can do these steps manually or use the AI coding tools for guidance. See [Create an integration](../starter-kit/integration/create-integration.md) for detailed configuration instructions.
+
 ## `dropins` MCP server for storefront development
 
-When you select the **AEM Boilerplate Commerce** starter kit, `tools-setup` additionally installs the [`@dropins/mcp`](https://www.npmjs.com/package/@dropins/mcp) server and a set of storefront-specific agent skills, alongside the standard `commerce-extensibility` MCP server and App Builder skills.
+If you select `AEM Boilerplate Commerce` in the `aio commerce extensibility tools-setup` command, the [`@dropins/mcp`](https://www.npmjs.com/package/@dropins/mcp) server and a set of storefront-specific agent skills are installed in addition to the standard `commerce-extensibility` MCP server and App Builder skills.
 
-The `dropins` MCP server provides structured, authoritative data about every drop-in component — slots, event payloads, container props, public API signatures, shared model types, design tokens, i18n keys, and GraphQL operations — extracted directly from the drop-in source repositories. Agent skills use this server as the primary source of truth for storefront customization tasks, falling back to TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+The `dropins` MCP server provides structured, authoritative data about every drop-in component extracted directly from the drop-in source repositories. Agent skills use this server as the primary reference for storefront customization tasks, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
 
-The tools-setup process:
+If you select `AEM Boilerplate Commerce` in the `aio commerce extensibility tools-setup` command, the tool:
 
-* Installs `@dropins/mcp` globally (`npm install -g @dropins/mcp@latest`) so the latest version is available immediately.
-* Configures your coding agent to run the server with `npx --yes @dropins/mcp`, so it starts automatically without prompting, whether or not the global install succeeded.
+* Installs `@dropins/mcp` globally (`npm install -g @dropins/mcp@latest`), so the latest version is available immediately.
+* Configures your coding agent to run the server with `npx --yes @dropins/mcp`, so it starts automatically without prompting.
 
 For the list of storefront skills and the `dropins` MCP tools they use, see [Storefront skills](skills-and-prompts.md#storefront-skills).
 
 ### Updating the `dropins` MCP server
 
-The server checks npm on startup and prints a warning to stderr if a newer stable version is available. To update manually:
+The server checks npm on startup and prints a warning to `stderr` if a newer stable version is available. To update manually run the following command:
 
 ```bash
 npm update -g @dropins/mcp
 ```
-
-<InlineAlert variant="info" slots="text" />
-
-Before deploying your project, complete configuration tasks: log in to [Adobe Developer Console](https://developer.adobe.com/console) using the Adobe I/O CLI, create an App Builder project (see [Project setup](../events/project-setup.md)), and set up environment variables in an `.env` file. You can do these steps manually or use the AI coding tools for guidance. See [Create an integration](../starter-kit/integration/create-integration.md) for detailed configuration instructions.
 
 ## Post-installation configuration
 

--- a/src/pages/developer-agent/coding-tools.md
+++ b/src/pages/developer-agent/coding-tools.md
@@ -227,7 +227,10 @@ Next steps:
       ? Which starter kit would you like to use?
       ❯ Integration starter kit
          Checkout starter kit
+         AEM Boilerplate Commerce
       ```
+
+      **Note:** Selecting **AEM Boilerplate Commerce** additionally installs and configures the [`dropins` MCP server](#dropins-mcp-server-for-storefront-development) and storefront-specific agent skills, alongside the `commerce-extensibility` MCP server.
 
    * Select your preferred coding agent. Over 40 coding agents are supported; if you do not see your preferred agent, use the `Other` option to install skills for any coding agent. Refer to your coding agent's documentation for how to configure skills.
 
@@ -258,6 +261,27 @@ Next steps:
    * Commerce-specific development tools and workflows
 
    Skills and MCP tools are installed. If you do not see them, restart your coding agent.
+
+## `dropins` MCP server for storefront development
+
+When you select the **AEM Boilerplate Commerce** starter kit, `tools-setup` additionally installs the [`@dropins/mcp`](https://www.npmjs.com/package/@dropins/mcp) server and a set of storefront-specific agent skills, alongside the standard `commerce-extensibility` MCP server and App Builder skills.
+
+The `dropins` MCP server provides structured, authoritative data about every drop-in component — slots, event payloads, container props, public API signatures, shared model types, design tokens, i18n keys, and GraphQL operations — extracted directly from the drop-in source repositories. Agent skills use this server as the primary source of truth for storefront customization tasks, falling back to TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+
+The tools-setup process:
+
+* Installs `@dropins/mcp` globally (`npm install -g @dropins/mcp@latest`) so the latest version is available immediately.
+* Configures your coding agent to run the server with `npx --yes @dropins/mcp`, so it starts automatically without prompting, whether or not the global install succeeded.
+
+For the list of storefront skills and the `dropins` MCP tools they use, see [Storefront skills](skills-and-prompts.md#storefront-skills).
+
+### Updating the `dropins` MCP server
+
+The server checks npm on startup and prints a warning to stderr if a newer stable version is available. To update manually:
+
+```bash
+npm update -g @dropins/mcp
+```
 
 <InlineAlert variant="info" slots="text" />
 

--- a/src/pages/developer-agent/dropins-mcp-server.md
+++ b/src/pages/developer-agent/dropins-mcp-server.md
@@ -1,0 +1,32 @@
+---
+title: dropins MCP server for storefront development
+description: Install, configure, and update the dropins MCP server for AEM Boilerplate Commerce storefront development.
+keywords:
+  - App Builder
+  - Cloud
+  - Extensibility
+  - Tools
+  - Storefront
+  - AEM Boilerplate Commerce
+---
+
+# `dropins` MCP server for storefront development
+
+If you select the `AEM Boilerplate Commerce` starter kit, the AI coding tools additionally install the [`@dropins/mcp`](https://www.npmjs.com/package/@dropins/mcp) server and a set of storefront-specific agent skills, alongside the standard `commerce-extensibility` MCP server and App Builder skills. This applies whether you choose the starter kit through the [automated setup](coding-tools.md#automated-setup-recommended) (`app-setup`) or the [manual setup](coding-tools.md#manual-setup) (`tools-setup`) flow.
+
+The `dropins` MCP server provides structured, authoritative data about every drop-in component extracted directly from the drop-in source repositories. Agent skills use this server as the primary reference for storefront customization tasks, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+
+When you select `AEM Boilerplate Commerce`, the setup process:
+
+* Installs `@dropins/mcp` globally (`npm install -g @dropins/mcp@latest`), so the latest version is available immediately.
+* Configures your coding agent to run the server with `npx --yes @dropins/mcp`, so it starts automatically without prompting.
+
+For the list of storefront skills and the `dropins` MCP tools they use, see [Storefront skills](skills-and-prompts.md#storefront-skills).
+
+## Updating the `dropins` MCP server
+
+The server checks npm on startup and prints a warning to `stderr` if a newer stable version is available. To update manually run the following command:
+
+```bash
+npm update -g @dropins/mcp
+```

--- a/src/pages/developer-agent/index.md
+++ b/src/pages/developer-agent/index.md
@@ -24,9 +24,9 @@ This section documents the current tooling and is structured so additional guide
 
 | Capability | Description |
 | --- | --- |
-| Agent skills | Commerce- and App Builder–specific skills that guide architecture, implementation, DevOps, requirements, docs, testing, and learning workflows. |
+| Agent skills | Commerce and App Builder skills that guide architecture, implementation, DevOps, requirements, docs, testing, and learning workflows. |
 | Adobe Commerce App Builder MCP server | IDE integration for Commerce development tasks, documentation-aware assistance, and tooling aligned with App Builder application development patterns. |
-| `dropins` MCP server | For storefronts built on the AEM Boilerplate Commerce starter kit — structured, authoritative data about drop-in slots, events, containers, APIs, models, and design tokens. |
+| `dropins` MCP server | For storefronts built on the AEM Boilerplate Commerce starter kit. Provides structured, authoritative data about drop-in slots, events, containers, APIs, models, and design tokens. |
 
 Together, these improve workflow integration, context-aware generation, and repeatable development and deployment steps.
 

--- a/src/pages/developer-agent/index.md
+++ b/src/pages/developer-agent/index.md
@@ -26,7 +26,7 @@ This section documents the current tooling and is structured so additional guide
 | --- | --- |
 | Agent skills | Commerce and App Builder skills that guide architecture, implementation, DevOps, requirements, docs, testing, and learning workflows. |
 | Adobe Commerce App Builder MCP server | IDE integration for Commerce development tasks, documentation-aware assistance, and tooling aligned with App Builder application development patterns. |
-| `dropins` MCP server | For storefronts built on the AEM Boilerplate Commerce starter kit. Provides structured, authoritative data about drop-in slots, events, containers, APIs, models, and design tokens. |
+| [`dropins` MCP server](dropins-mcp-server.md) | For storefronts built on the AEM Boilerplate Commerce starter kit. Provides structured, authoritative data about drop-in slots, events, containers, APIs, models, and design tokens. |
 
 Together, these improve workflow integration, context-aware generation, and repeatable development and deployment steps.
 
@@ -35,6 +35,7 @@ Together, these improve workflow integration, context-aware generation, and repe
 | Guide | Description |
 | --- | --- |
 | [Coding tools setup](coding-tools.md) | Prerequisites, installation with `aio commerce extensibility tools-setup`, post-install CLI auth, and IDE configuration (for example Cursor and GitHub Copilot). |
+| [`dropins` MCP server](dropins-mcp-server.md) | Installation, update, and skill integration details for the `dropins` MCP server used on AEM Boilerplate Commerce storefronts. |
 | [Use cases](use-cases.md) | Common extension patterns — REST APIs, checkout extensions, storefront components, event-driven integrations, and more. |
 | [Skills, prompts, and commands](skills-and-prompts.md) | Slash commands, sample prompts, and the `/search-commerce-docs` command. |
 | [Best practices](best-practices.md) | Planning mode, session checklists, workflow and protocol, MCP vs CLI, testing, deployment, monitoring, anti-patterns, and feedback. |

--- a/src/pages/developer-agent/index.md
+++ b/src/pages/developer-agent/index.md
@@ -18,6 +18,7 @@ This section documents the current tooling and is structured so additional guide
 
 - Developers using Adobe Commerce as a Cloud Service (and related SaaS offerings) who want guided, Commerce-aware assistance in the IDE.
 - Teams standardizing on agent skills and MCP (Model Context Protocol) integrations for documentation and App Builder workflows.
+- Developers customizing storefronts built on the [AEM Boilerplate Commerce](https://github.com/hlxsites/aem-boilerplate-commerce) starter kit who want AI assistance grounded in authoritative drop-in component data.
 
 ## What you get
 
@@ -25,6 +26,7 @@ This section documents the current tooling and is structured so additional guide
 | --- | --- |
 | Agent skills | Commerce- and App Builder–specific skills that guide architecture, implementation, DevOps, requirements, docs, testing, and learning workflows. |
 | Adobe Commerce App Builder MCP server | IDE integration for Commerce development tasks, documentation-aware assistance, and tooling aligned with App Builder application development patterns. |
+| `dropins` MCP server | For storefronts built on the AEM Boilerplate Commerce starter kit — structured, authoritative data about drop-in slots, events, containers, APIs, models, and design tokens. |
 
 Together, these improve workflow integration, context-aware generation, and repeatable development and deployment steps.
 

--- a/src/pages/developer-agent/skills-and-prompts.md
+++ b/src/pages/developer-agent/skills-and-prompts.md
@@ -64,7 +64,7 @@ Skills are invoked automatically when you chat with your coding agent. You can a
 
 ## Storefront skills
 
-When you select the **AEM Boilerplate Commerce** starter kit during [setup](coding-tools.md#dropins-mcp-server-for-storefront-development), a separate set of skills is installed for storefront development. These skills route drop-in data queries (slots, events, containers, and API functions) to the `dropins` MCP server as the primary reference, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+When you select the **AEM Boilerplate Commerce** starter kit during [setup](dropins-mcp-server.md), a separate set of skills is installed for storefront development. These skills route drop-in data queries (slots, events, containers, and API functions) to the `dropins` MCP server as the primary reference, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
 
 | Command | Purpose |
 | --- | --- |

--- a/src/pages/developer-agent/skills-and-prompts.md
+++ b/src/pages/developer-agent/skills-and-prompts.md
@@ -61,3 +61,38 @@ Skills are invoked automatically when you chat with your coding agent. You can a
 | `/technical-writer` | Creates comprehensive documentation for App Builder applications. Use when writing `README.md`, user guides, API documentation, changelogs, or ensuring documentation completeness. |
 | `/tester` | Creates comprehensive tests for App Builder applications. Use when writing unit tests, integration tests, validating security, or ensuring code quality and coverage. |
 | `/tutor` (experimental) | Teaches Adobe Commerce application development concepts with clear explanations and examples. Use when learning App Builder, understanding events, or needing guidance on development patterns. |
+
+## Storefront skills
+
+When you select the **AEM Boilerplate Commerce** starter kit during [setup](coding-tools.md#dropins-mcp-server-for-storefront-development), a separate set of skills is installed for storefront development. These skills route drop-in data queries (slots, events, containers, API functions) to the `dropins` MCP server as the primary source, falling back to TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+
+| Command | Purpose |
+| --- | --- |
+| `/project-manager` | Gathers storefront requirements, analyzes the current project state with `dropins:analyze_project`, and manages the phased development protocol. |
+| `/researcher` | Looks up authoritative drop-in data — slots, events, containers, API functions, models, design tokens, and i18n keys — before any implementation work. |
+| `/dropin-developer` | Scaffolds blocks, slots, and checkout extensions wired to real drop-in containers, and suggests slot implementations and event handlers. |
+| `/block-developer` | Implements and modifies AEM blocks that consume drop-in containers, following the boilerplate's file structure and conventions. |
+| `/content-modeler` | Models content structures and authoring patterns for AEM Universal Editor blocks. |
+| `/tester` | Runs pre-test health checks (`dropins:check_config`, `dropins:check_block_health`, `dropins:get_upgrade_diff`) and validates storefront behavior in the browser. |
+
+### `dropins` MCP tools
+
+The storefront skills call the following `dropins` MCP tools directly. You can also invoke them yourself in a prompt.
+
+| Need to know | MCP tool |
+| --- | --- |
+| Slot names and context shapes for a container | `dropins:list_slots` |
+| Event names, payloads, producers, consumers | `dropins:list_events` |
+| Container names and their props | `dropins:list_containers` |
+| Public API function signatures | `dropins:list_api_functions` |
+| Shared model/type definitions (CartModel, Price, etc.) | `dropins:list_models` |
+| CSS design tokens by category | `dropins:list_design_tokens` |
+| i18n dictionary keys and defaults | `dropins:list_i18n_keys` |
+| Available GraphQL operations | `dropins:list_graphql_queries` |
+| Event emitters, consumers, and sample code | `dropins:explain_event_flow` |
+| Keyword search across storefront docs | `dropins:search_docs` |
+| Block health — outdated container/slot/API references | `dropins:check_block_health` |
+| Storefront config validation (endpoints, environment) | `dropins:check_config` |
+| Drop-in version gaps vs. the registry | `dropins:get_upgrade_diff` |
+| Installed drop-ins, block inventory, version state | `dropins:analyze_project` |
+| Scaffold a block, slot, or checkout extension | `dropins:scaffold_block` / `dropins:scaffold_slot` / `dropins:scaffold_extension` |

--- a/src/pages/developer-agent/skills-and-prompts.md
+++ b/src/pages/developer-agent/skills-and-prompts.md
@@ -64,13 +64,13 @@ Skills are invoked automatically when you chat with your coding agent. You can a
 
 ## Storefront skills
 
-When you select the **AEM Boilerplate Commerce** starter kit during [setup](coding-tools.md#dropins-mcp-server-for-storefront-development), a separate set of skills is installed for storefront development. These skills route drop-in data queries (slots, events, containers, API functions) to the `dropins` MCP server as the primary source, falling back to TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
+When you select the **AEM Boilerplate Commerce** starter kit during [setup](coding-tools.md#dropins-mcp-server-for-storefront-development), a separate set of skills is installed for storefront development. These skills route drop-in data queries (slots, events, containers, and API functions) to the `dropins` MCP server as the primary reference, and fallback to the TypeScript definitions in `node_modules/@dropins/` when the server is unavailable.
 
 | Command | Purpose |
 | --- | --- |
 | `/project-manager` | Gathers storefront requirements, analyzes the current project state with `dropins:analyze_project`, and manages the phased development protocol. |
-| `/researcher` | Looks up authoritative drop-in data — slots, events, containers, API functions, models, design tokens, and i18n keys — before any implementation work. |
-| `/dropin-developer` | Scaffolds blocks, slots, and checkout extensions wired to real drop-in containers, and suggests slot implementations and event handlers. |
+| `/researcher` | Looks up authoritative drop-in data for slots, events, containers, API functions, models, design tokens, and i18n keys before any implementation work. |
+| `/dropin-developer` | Scaffolds blocks, slots, and checkout extensions wired to real drop-in containers, and then suggests slot implementations and event handlers. |
 | `/block-developer` | Implements and modifies AEM blocks that consume drop-in containers, following the boilerplate's file structure and conventions. |
 | `/content-modeler` | Models content structures and authoring patterns for AEM Universal Editor blocks. |
 | `/tester` | Runs pre-test health checks (`dropins:check_config`, `dropins:check_block_health`, `dropins:get_upgrade_diff`) and validates storefront behavior in the browser. |
@@ -81,18 +81,18 @@ The storefront skills call the following `dropins` MCP tools directly. You can a
 
 | Need to know | MCP tool |
 | --- | --- |
-| Slot names and context shapes for a container | `dropins:list_slots` |
-| Event names, payloads, producers, consumers | `dropins:list_events` |
-| Container names and their props | `dropins:list_containers` |
-| Public API function signatures | `dropins:list_api_functions` |
-| Shared model/type definitions (CartModel, Price, etc.) | `dropins:list_models` |
-| CSS design tokens by category | `dropins:list_design_tokens` |
-| i18n dictionary keys and defaults | `dropins:list_i18n_keys` |
-| Available GraphQL operations | `dropins:list_graphql_queries` |
-| Event emitters, consumers, and sample code | `dropins:explain_event_flow` |
-| Keyword search across storefront docs | `dropins:search_docs` |
-| Block health — outdated container/slot/API references | `dropins:check_block_health` |
-| Storefront config validation (endpoints, environment) | `dropins:check_config` |
-| Drop-in version gaps vs. the registry | `dropins:get_upgrade_diff` |
-| Installed drop-ins, block inventory, version state | `dropins:analyze_project` |
-| Scaffold a block, slot, or checkout extension | `dropins:scaffold_block` / `dropins:scaffold_slot` / `dropins:scaffold_extension` |
+| Lists slot names and context shapes for a container | `dropins:list_slots` |
+| Lists event names, payloads, producers, and consumers | `dropins:list_events` |
+| Lists container names and their props | `dropins:list_containers` |
+| Lists public API function signatures | `dropins:list_api_functions` |
+| Lists shared model/type definitions, such as `CartModel` or `Price` | `dropins:list_models` |
+| Lists CSS design tokens by category | `dropins:list_design_tokens` |
+| Lists i18n dictionary keys and defaults | `dropins:list_i18n_keys` |
+| Lists available GraphQL operations | `dropins:list_graphql_queries` |
+| Explains event emitters, consumers, and sample code | `dropins:explain_event_flow` |
+| Performs a keyword search across storefront docs | `dropins:search_docs` |
+| Checks the block health and indicates any outdated container, slot, or API references | `dropins:check_block_health` |
+| Validates the storefront configuration, including endpoints and environment settings | `dropins:check_config` |
+| Performs a diff comparing drop-in version gaps and the registry | `dropins:get_upgrade_diff` |
+| Analyzes installed drop-ins, block inventory, and version state | `dropins:analyze_project` |
+| Scaffolds a block, slot, or checkout extension | `dropins:scaffold_block` / `dropins:scaffold_slot` / `dropins:scaffold_extension` |

--- a/src/pages/developer-agent/use-cases.md
+++ b/src/pages/developer-agent/use-cases.md
@@ -34,9 +34,9 @@ See the [Shipping method extension tutorial](https://experienceleague.adobe.com/
 
 ## Storefront UI components
 
-Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. When you install the tools with the [AEM Boilerplate Commerce starter kit](coding-tools.md#dropins-mcp-server-for-storefront-development), the AI tools use the `dropins` MCP server to look up real slot names, event payloads, and API signatures against the drop-in registry — instead of guessing from documentation alone — then propose architecture options and generate accessible, responsive components with scoped styles and loading states.
+Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. When you install the tools with the [AEM Boilerplate Commerce starter kit](coding-tools.md#dropins-mcp-server-for-storefront-development), the AI tools use the `dropins` MCP server to look up real slot names, event payloads, and API signatures against the drop-in registry. Then they propose architecture options and generate accessible, responsive components with scoped styles and loading states.
 
-**Example — Star ratings on product detail pages (PDP):** Render a star-rating display with review count on the PDP by customizing a drop-in slot or creating a standalone block that fetches data from your ratings API. Ask the `/dropin-developer` skill to verify the slot exists with `dropins:list_slots` before scaffolding it.
+**Example — Star ratings on product detail pages (PDP):** Render a star-rating display with review count on the PDP by customizing a drop-in slot or creating a standalone block that fetches data from your ratings API. Ask the `/dropin-developer` skill to verify that the slot exists with `dropins:list_slots` before scaffolding it.
 
 ## Event-driven back-office integrations
 

--- a/src/pages/developer-agent/use-cases.md
+++ b/src/pages/developer-agent/use-cases.md
@@ -34,9 +34,9 @@ See the [Shipping method extension tutorial](https://experienceleague.adobe.com/
 
 ## Storefront UI components
 
-Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. The AI tools research your codebase and Commerce documentation, propose architecture options, and generate accessible, responsive components with scoped styles and loading states.
+Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. When you install the tools with the [AEM Boilerplate Commerce starter kit](coding-tools.md#dropins-mcp-server-for-storefront-development), the AI tools use the `dropins` MCP server to look up real slot names, event payloads, and API signatures against the drop-in registry — instead of guessing from documentation alone — then propose architecture options and generate accessible, responsive components with scoped styles and loading states.
 
-**Example — Star ratings on product detail pages (PDP):** Render a star-rating display with review count on the PDP by customizing a drop-in slot or creating a standalone block that fetches data from your ratings API.
+**Example — Star ratings on product detail pages (PDP):** Render a star-rating display with review count on the PDP by customizing a drop-in slot or creating a standalone block that fetches data from your ratings API. Ask the `/dropin-developer` skill to verify the slot exists with `dropins:list_slots` before scaffolding it.
 
 ## Event-driven back-office integrations
 

--- a/src/pages/developer-agent/use-cases.md
+++ b/src/pages/developer-agent/use-cases.md
@@ -34,7 +34,7 @@ See the [Shipping method extension tutorial](https://experienceleague.adobe.com/
 
 ## Storefront UI components
 
-Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. When you install the tools with the [AEM Boilerplate Commerce starter kit](coding-tools.md#dropins-mcp-server-for-storefront-development), the AI tools use the `dropins` MCP server to look up real slot names, event payloads, and API signatures against the drop-in registry. Then they propose architecture options and generate accessible, responsive components with scoped styles and loading states.
+Create new UI blocks or customize existing [drop-in component slots](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) on Edge Delivery Services storefronts. When you install the tools with the [AEM Boilerplate Commerce starter kit](dropins-mcp-server.md), the AI tools use the `dropins` MCP server to look up real slot names, event payloads, and API signatures against the drop-in registry. Then they propose architecture options and generate accessible, responsive components with scoped styles and loading states.
 
 **Example — Star ratings on product detail pages (PDP):** Render a star-rating display with review count on the PDP by customizing a drop-in slot or creating a standalone block that fetches data from your ratings API. Ask the `/dropin-developer` skill to verify that the slot exists with `dropins:list_slots` before scaffolding it.
 


### PR DESCRIPTION


## Purpose of this pull request
Documents the dropins MCP server and storefront-specific agent skills that get installed automatically when developers select the AEM Boilerplate Commerce starter kit in tools-setup. Previously, this integration had no coverage in the developer docs.

Changes:

- New section explaining what the dropins MCP server does and how it's installed/updated
- New "Storefront skills" section listing the 6 storefront skills and the dropins MCP tools they use
- Updated capability overview and storefront use case to reference the new tooling

Ticket 
USF-4113
## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
