### PR TITLE
CEXT-6484: Release commerce eventing 1.21.0

### DIFF
--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -20,13 +20,13 @@ July 14, 2026
 
 ### Enhancements
 
-* Added event name validation for new event subscriptions.
+* Added event name validation for new event subscriptions. \<!-- CEXT-6164 --\>
 
-* Improved event name validation and removed unnecessary files from module generation.
+* Improved event name validation and removed unnecessary files from module generation. \<!-- CEXT-6303 --\>
 
 ### Bug fixes
 
-* Fixed event field filtering for events with uppercase alias characters.
+* Fixed event field filtering for events with uppercase alias characters. \<!-- CEXT-6162 --\>
 
 ## Version 1.20.0
 

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,22 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.21.0
+
+### Release date
+
+July 14, 2026
+
+### Enhancements
+
+* Added event name validation for new event subscriptions.
+
+* Improved event name validation and removed unnecessary files from module generation.
+
+### Bug fixes
+
+* Fixed event field filtering for events with uppercase alias characters.
+
 ## Version 1.20.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for the new eventing version 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/extensibility/events/release-notes

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
