### PR TITLE
ACCS-972: Docs for getting product custom options and quantity

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -390,7 +390,7 @@ Source: context_checkout_session.get_quote.get_sub_total
 Active: Yes
 ```
 
-To get the product custom options such as Text Field, Text Area, Radio Button, Check box or product quantity while adding the product to cart via Storefront or Graphql API.x
+To get the product custom options such as Text Field, Text Area, Radio Button, Check box or product quantity while adding the product to cart via Storefront or Graphql API.
 
 <CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -390,6 +390,30 @@ Source: context_checkout_session.get_quote.get_sub_total
 Active: Yes
 ```
 
+To get the product custom options such as Text Field, Text Area, Radio Button, Check box or product quantity while adding the product to cart via Storefront or Graphql API.x
+
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+
+##### webhooks.xml (PaaS)
+
+```xml
+<fields>
+    <field name="custom_options" source="context_quote_item_options.get_options" />
+    <field name="quantity"       source="context_quote_item_options.get_qty" />
+</fields>
+```
+
+##### Admin (SaaS)
+
+```yaml
+Hook Fields
+Name: custom_options
+Source: context_quote_item_options.get_options
+Name: quantity
+Source: context_quote_item_options.get_qty
+Active: Yes
+```
+
 ### Context headers
 
 You can use the same syntax and features available for context values in fields to set hook headers.

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -390,7 +390,7 @@ Source: context_checkout_session.get_quote.get_sub_total
 Active: Yes
 ```
 
-To get the product custom options such as Text Field, Text Area, Radio Button, Check box or product quantity while adding the product to cart via Storefront or Graphql API.
+To get the product custom options such as text field, text area, radio button, check box, or product quantity while adding the product to cart from the storefront or GraphQL API.
 
 <CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
 

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -415,6 +415,7 @@ Name: quantity
 Source: context_quote_item_options.get_qty
 Active: Yes
 ```
+
 --\>
 
 ### Context headers

--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -392,7 +392,7 @@ Active: Yes
 
 To get the product custom options such as text field, text area, radio button, check box, or product quantity while adding the product to cart from the storefront or GraphQL API.
 
-<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
+<CodeBlock slots="heading, code" repeat="1" languages="XML, YAML" />
 
 ##### webhooks.xml (PaaS)
 
@@ -402,6 +402,8 @@ To get the product custom options such as text field, text area, radio button, c
     <field name="quantity"       source="context_quote_item_options.get_qty" />
 </fields>
 ```
+
+\<!--
 
 ##### Admin (SaaS)
 
@@ -413,6 +415,7 @@ Name: quantity
 Source: context_quote_item_options.get_qty
 Active: Yes
 ```
+--\>
 
 ### Context headers
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -17,7 +17,7 @@ July 27, 2026
 
 ### Enhancements
 
-The `observer.sales_quote_item_set_product` webhook payload now includes shopper-entered custom option values. \<!-- ACCS-972 --\>
+On PaaS, the `observer.sales_quote_item_set_product` webhook payload now includes shopper-entered custom option values. \<!-- ACCS-972 --\>
 
 ## Version 1.18.0
 

--- a/src/pages/webhooks/release-notes.md
+++ b/src/pages/webhooks/release-notes.md
@@ -9,6 +9,16 @@ keywords:
 
 These release notes describe the latest version of Adobe Commerce Webhooks.
 
+## Version 1.19.0
+
+### Release date
+
+July 27, 2026
+
+### Enhancements
+
+The `observer.sales_quote_item_set_product` webhook payload now includes shopper-entered custom option values. \<!-- ACCS-972 --\>
+
 ## Version 1.18.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request
https://jira.corp.adobe.com/browse/ACCS-972
Implemented CRANE's request to retrieve the product custom options during the add-to-cart process.

## Affected pages

https://developer.adobe.com/commerce/extensibility/webhooks/hooks#context-values

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
