### PR TITLE
CEXT-6421: fix starter kit links.

### DIFF
--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -53,7 +53,9 @@ Some requirements will differ based on whether you indicated the app was non-dow
 
       - If the app is compatible with the EDS storefront, include instructions for setup. [Example documentation](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/create-storefront/)
       - If the app uses a Mesh, provide detailed information on how to configure it according to Adobe guidelines. [Example documentation](https://developer.adobe.com/graphql-mesh-gateway/mesh/basic/create-mesh)
-      - If the app uses eventing, provide information about the events used in the project and how to subscribe to them. [Example documentation]([https://github.com/adobe/commerce-integration-starter-kit?tab=readme-ov-file#onboarding](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#configure-eventing))
+      - If the app uses eventing, provide information about the events used in the project and how to subscribe to them. Example documentation:
+         - [Integration starter kit overview](https://github.com/adobe/commerce-integration-starter-kit?tab=readme-ov-file#onboarding
+         - [Configure eventing in the checkout starter kit](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#configure-eventing)
       - If the app uses webhooks, provide information on how to create a webhook. [Example documentation](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#configure-webhooks)
   - **Version requirements**: Indicate the required module versions (example: Admin UI SDK minimum version `3.0.0`).
   - **Developer documentation**: Include links to relevant Adobe developer documentation (example: App Builder [getting started guide](https://developer.adobe.com/app-builder/docs/get_started/)).

--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -53,8 +53,8 @@ Some requirements will differ based on whether you indicated the app was non-dow
 
       - If the app is compatible with the EDS storefront, include instructions for setup. [Example documentation](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/create-storefront/)
       - If the app uses a Mesh, provide detailed information on how to configure it according to Adobe guidelines. [Example documentation](https://developer.adobe.com/graphql-mesh-gateway/mesh/basic/create-mesh)
-      - If the app uses eventing, provide information about the events used in the project and how to subscribe to them. [Example documentation](https://github.com/adobe/commerce-integration-starter-kit?tab=readme-ov-file#onboarding)
-      - If the app uses webhooks, provide information on how to create a webhook. [Example documentation](https://github.com/adobe/commerce-checkout-starter-kit?tab=readme-ov-file#create-webhooks)
+      - If the app uses eventing, provide information about the events used in the project and how to subscribe to them. [Example documentation]([https://github.com/adobe/commerce-integration-starter-kit?tab=readme-ov-file#onboarding](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#configure-eventing))
+      - If the app uses webhooks, provide information on how to create a webhook. [Example documentation](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#configure-webhooks)
   - **Version requirements**: Indicate the required module versions (example: Admin UI SDK minimum version `3.0.0`).
   - **Developer documentation**: Include links to relevant Adobe developer documentation (example: App Builder [getting started guide](https://developer.adobe.com/app-builder/docs/get_started/)).
   - **PaaS support**: Documentation must include installation steps for PaaS merchants. This means if you are submitting an app for Adobe Commerce as a Cloud Service (SaaS), you also need to support Adobe Commerce on cloud infrastructure (PaaS) and Adobe Commerce on-premises (on-prem).
@@ -63,8 +63,8 @@ Some requirements will differ based on whether you indicated the app was non-dow
     - Explain differences in the structure of the `COMMERCE_BASE_URL` value  if the variable is used (see [Download and configure the integration starter kit](../starter-kit/integration/create-integration.md#download-and-configure-the-integration-starter-kit) for an explanation)
     - Mention in the documentation how to obtain auth credentials for [PaaS](../starter-kit/integration/create-integration.md#paas-or-saas) and [SaaS](../starter-kit/integration/create-integration.md#create-an-integration-in-adobe-commerce-as-a-cloud-service)
   - For downloadable apps:
-    - **Environment setup**: Label all required environment variables in an [`env.dist`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/env.dist) file with clear guidance. Add a setup instruction to create an `.env` file from the `env.dist`.
-    - **API requirements**: List the required services for your application following [this template](https://github.com/adobe/commerce-checkout-starter-kit?tab=readme-ov-file#initialize-app-builder-project).
+    - **Environment setup**: Label all required environment variables in an `env.dist` file with clear guidance. Add a setup instruction to create an `.env` file from the `env.dist`.
+    - **API requirements**: List the required services for your application following [this template](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/SUBMISSION_TEMPLATE.md#initialize-app-builder-project).
     - **Project creation**:
         - Document how to create a project and workspaces for deploying the app. Consider linking to [Create your First App Builder Application](https://developer.adobe.com/app-builder/docs/get_started/app_builder_get_started/first-app)
         - Document CLI commands for installing dependencies and connecting to the created project, which are mentioned in [Configure the starter kit](../starter-kit/integration/create-integration.md#configure-the-starter-kit)
@@ -162,7 +162,7 @@ The following best practices are not required for your app to be accepted, but t
 ### Project enhancement
 
 - Tracking and monitoring
-  - **Starter kit info**: Include the [`starter-kit-info`](https://github.com/adobe/commerce-integration-starter-kit/blob/main/actions/starter-kit-info/index.js) runtime action for deployment tracking.
+  - **Starter kit info**: Include the [`starter-kit-info`](https://github.com/adobe/commerce-integration-starter-kit/blob/main/src/commerce-extensibility-1/actions/starter-kit/info/index.js) runtime action for deployment tracking.
   - **Feature utilization**: Leverage new starter kit features where applicable.
     - [Integration starter kit](../starter-kit/integration/index.md)
     - [Checkout starter kit](../starter-kit/checkout/index.md)

--- a/src/pages/app-development/extension-compatibility.md
+++ b/src/pages/app-development/extension-compatibility.md
@@ -43,8 +43,8 @@ For more information on REST API access, refer to the [Developer Console configu
 
 For older versions of the starter kit, check if your code is adapted as follows:
 
-- To support both PaaS and SaaS, modify the `COMMERCE_BASE_URL` environment variable according to the [Commerce integration guide](../starter-kit/checkout/connect.md).
-- Ensure that your [adobe-commerce](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/lib/adobe-commerce.js) HTTP client removes the `rest/all` prefix for compatibility with both deployment flavors. For example:
+- To support both PaaS and SaaS, modify the `COMMERCE_BASE_URL` environment variable in `.env` file.
+- Ensure that your Adobe Commerce HTTP client removes the `rest/all` prefix for compatibility with both deployment flavors. For example:
 
     ```javascript
     - commerceGot(`rest/all/V1/oope_payment_method/`, {
@@ -93,7 +93,7 @@ Refer to [URL structure](https://developer.adobe.com/commerce/webapi/rest/#url-s
     }
     ```
 
-    For more information, see the [full example](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/commerce-backend-ui-1/web-src/src/components/MainPage.js).
+    For more information, see the [full example](https://github.com/adobe/adobe-commerce-samples/blob/main/admin-ui-sdk/menu/custom-menu/src/commerce-backend-ui-1/web-src/src/components/MainPage.js).
 
 ## Out-of-process extensibility modules
 

--- a/src/pages/starter-kit/checkout/connect.md
+++ b/src/pages/starter-kit/checkout/connect.md
@@ -10,7 +10,7 @@ keywords:
 
 This guide explains how to integrate the checkout starter kit with Adobe Commerce.
 
-The [`adobe-commerce.js`](https://github.com/adobe/commerce-checkout-starter-kit/blob/main/lib/adobe-commerce.js) file provides a set of methods to interact with the Adobe Commerce instance. The client uses the Adobe Commerce HTTP Client, which is a wrapper around the Adobe Commerce REST API.
+The `adobe-commerce.js` file provides a set of methods to interact with the Adobe Commerce instance. The client uses the Adobe Commerce HTTP Client, which is a wrapper around the Adobe Commerce REST API.
 
 To use the Adobe Commerce HTTP Client, update the `COMMERCE_BASE_URL` value in the `.env` file, and complete the authentication setup.
 


### PR DESCRIPTION
## Purpose of this pull request

After refactoring starter kits some links got broken, this PR attempts to fix them.
Please consider that some of the files has been rewritten in #578

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
