### PR TITLE
fix constant name

### DIFF
--- a/src/pages/app-management/installation/admin-ui-sdk.md
+++ b/src/pages/app-management/installation/admin-ui-sdk.md
@@ -29,7 +29,7 @@ Declare a single Commerce Admin menu entry for the application. Use the named co
 
 ```js
 import { defineConfig } from "@adobe/aio-commerce-lib-app/config"
-import { MENU_CATALOG } from "@adobe/aio-commerce-lib-admin-ui/menu";
+import { MENU_SALES } from "@adobe/aio-commerce-lib-admin-ui/menu";
 
 export default defineConfig({
   metadata: {


### PR DESCRIPTION
## Purpose of this pull request

Fixes a copy-paste error in the Admin UI SDK configuration example. The code sample imported `MENU_CATALOG` from `@adobe/aio-commerce-lib-admin-ui/menu` but used it as `parentMenu: MENU_SALES`, which would fail since `MENU_SALES` was never imported. Updated the import to match the constant actually used in the example.

## Affected pages

- https://developer.adobe.com/commerce/extensibility/app-management/installation/admin-ui-sdk/
