### PR TITLE
CEXT-6547: Release commerce eventing 1.22.0

### DIFF
--- a/src/pages/events/convert-field-values.md
+++ b/src/pages/events/convert-field-values.md
@@ -146,3 +146,27 @@ The following example updates the value of the field `visibility` present in the
     </event>
 </config>
 ```
+
+## Field-aware event conversion
+
+<Edition slots="text" backgroundcolor="blue" />
+
+[PaaS Only](https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions)
+
+By default, Commerce builds the entire source object (order, quote, product, and so on) before trimming it down to the fields you subscribed to. For large records, this intermediate build can use significantly more memory and processing than the delivered payload requires.
+
+When you enable field-aware event conversion, Commerce collects only the fields you subscribed to, plus any fields used by your event rules, instead of first building the complete source object. The data delivered to your destinations does not change — only how it is built internally.
+
+Field-aware conversion helps most when you subscribe to a narrow set of fields on large records, such as orders or quotes with many items. Subscriptions that use a wildcard (`fields:*`) still build the full object, but they are protected from producing excessively large payloads by an early size check.
+
+### Enable field-aware event conversion
+
+In the Commerce Admin, navigate to **Stores** > Settings > **Configuration** > **Adobe Services** > **Adobe I/O Events** > **Commerce events**, and set **Field-aware event conversion** to **Yes**. This setting is disabled by default.
+
+You can also enable it from the command line:
+
+```bash
+bin/magento config:set adobe_io_events/eventing/field_aware_conversion_enabled 1
+```
+
+This setting takes effect immediately for any environment running version 1.22.0 or later of the eventing modules.

--- a/src/pages/events/convert-field-values.md
+++ b/src/pages/events/convert-field-values.md
@@ -153,7 +153,7 @@ The following example updates the value of the field `visibility` present in the
 
 [PaaS Only](https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions)
 
-By default, Commerce builds the entire source object (order, quote, product, and so on) before trimming it down to the fields you subscribed to. For large records, this intermediate build can use significantly more memory and processing than the delivered payload requires.
+By default, Commerce builds the entire source object (such as order, quote, or product) before trimming it down to the fields you subscribed to. For large records, this intermediate build can use significantly more memory and processing than the delivered payload requires.
 
 When you enable field-aware event conversion, Commerce collects only the fields you subscribed to, plus any fields used by your event rules, instead of first building the complete source object. The data delivered to your destinations does not change — only how it is built internally.
 

--- a/src/pages/events/release-notes.md
+++ b/src/pages/events/release-notes.md
@@ -12,6 +12,20 @@ These release notes describe the latest version of Adobe I/O Events for Adobe Co
 
 See [Update Adobe I/O Events for Adobe Commerce](installation.md#update-adobe-io-events-for-adobe-commerce) for upgrade instructions.
 
+## Version 1.22.0
+
+### Release date
+
+August 6, 2026
+
+### Enhancements
+
+* Added an opt-in setting to build only the event fields you subscribed to instead of the entire source object before filtering, reducing memory and processing for large records. See [Convert payload field values](convert-field-values.md#field-aware-event-conversion). \<!-- CEXT-6501 --\>
+
+### Bug fixes
+
+* Fixed an issue where the `commerce.eventing.event.publish` message queue could accumulate a large backlog of priority events instead of draining as events were processed. \<!-- CEXT-6541 --\>
+
 ## Version 1.21.0
 
 ### Release date


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds release notes for the eventing release and describes a new configuration setting.

https://jira.corp.adobe.com/browse/CEXT-6547

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

-  https://developer.adobe.com/commerce/extensibility/events/release-notes
- https://developer.adobe.com/commerce/extensibility/events/convert-field-values

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-extensibility/blob/main/.github/CONTRIBUTING.md) for more information.
-->
