### PR TITLE
Add Adobe Commerce SDK best practice

### DIFF
--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -180,7 +180,7 @@ The following best practices are not required for your app to be accepted, but t
     Apps that adopt full App Management additionally require `@adobe/aio-commerce-lib-app` and `@adobe/aio-commerce-lib-config`, but the libraries above can be used independently for apps not yet using App Management.
 
   - **App Management**: Use [App Management](../app-management/index.md) to define your configuration schema, event subscriptions, and Admin UI once in an `app.commerce.config` file, and let the system auto-generate the required runtime actions and Admin UI. This is the Adobe-endorsed approach for installing, configuring, and managing App Builder applications in Commerce, and removes the need for merchants to manually configure event providers, subscriptions, or environment variables.
-    - Requires [Admin UI SDK](../admin-ui-sdk/index.md)
+    - Requires [Admin UI SDK](../admin-ui-sdk/index.md) version 3.3.1 or later.
     - Requires minimum library versions 1.0.0 or later for `@adobe/aio-commerce-lib-config`, `@adobe/aio-commerce-lib-app`, and `@adobe/aio-commerce-sdk`.
     - Not currently supported for local Commerce installations — requires a hosted (cloud or on-premises) environment.
 

--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -179,8 +179,8 @@ The following best practices are not required for your app to be accepted, but t
 
     Apps that adopt full App Management additionally require `@adobe/aio-commerce-lib-app` and `@adobe/aio-commerce-lib-config`, but the libraries above can be used independently for apps not yet using App Management.
 
-  - **App Management**: Use [App Management](https://developer.adobe.com/commerce/extensibility/app-management/) to define your configuration schema, event subscriptions, and Admin UI once in an `app.commerce.config` file, and let the system auto-generate the required runtime actions and Admin UI. This is the Adobe-endorsed approach for installing, configuring, and managing App Builder applications in Commerce, and removes the need for merchants to manually configure event providers, subscriptions, or environment variables.
-    - Requires [Admin UI SDK](https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/) version 3.3.1 or later.
+  - **App Management**: Use [App Management](../app-management/index.md) to define your configuration schema, event subscriptions, and Admin UI once in an `app.commerce.config` file, and let the system auto-generate the required runtime actions and Admin UI. This is the Adobe-endorsed approach for installing, configuring, and managing App Builder applications in Commerce, and removes the need for merchants to manually configure event providers, subscriptions, or environment variables.
+    - Requires [Admin UI SDK](../admin-ui-sdk/index.md)
     - Requires minimum library versions 1.0.0 or later for `@adobe/aio-commerce-lib-config`, `@adobe/aio-commerce-lib-app`, and `@adobe/aio-commerce-sdk`.
     - Not currently supported for local Commerce installations — requires a hosted (cloud or on-premises) environment.
 

--- a/src/pages/app-development/app-submission-guidelines.md
+++ b/src/pages/app-development/app-submission-guidelines.md
@@ -169,6 +169,21 @@ The following best practices are not required for your app to be accepted, but t
     - [Integration starter kit](../starter-kit/integration/index.md)
     - [Checkout starter kit](../starter-kit/checkout/index.md)
 
+- Adobe Commerce SDK
+  - **Typed API clients**: Use packages from the [Adobe Commerce SDK](https://github.com/adobe/aio-commerce-sdk) family instead of writing custom HTTP/auth/eventing logic from scratch. These libraries provide typed clients, built-in authentication, and retry logic, and keep your code aligned with Adobe's recommended patterns:
+    - `@adobe/aio-commerce-lib-auth` — authentication flows for Adobe IMS and Commerce integrations
+    - `@adobe/aio-commerce-lib-api` — HTTP/API client builders for Adobe Commerce and Adobe I/O Events
+    - `@adobe/aio-commerce-lib-events` — event-driven integrations between Commerce and Adobe I/O Events
+    - `@adobe/aio-commerce-lib-webhooks` — utilities for the Adobe Commerce Webhooks API
+    - `@adobe/aio-commerce-lib-core` — shared foundational utilities used across the family
+
+    Apps that adopt full App Management additionally require `@adobe/aio-commerce-lib-app` and `@adobe/aio-commerce-lib-config`, but the libraries above can be used independently for apps not yet using App Management.
+
+  - **App Management**: Use [App Management](https://developer.adobe.com/commerce/extensibility/app-management/) to define your configuration schema, event subscriptions, and Admin UI once in an `app.commerce.config` file, and let the system auto-generate the required runtime actions and Admin UI. This is the Adobe-endorsed approach for installing, configuring, and managing App Builder applications in Commerce, and removes the need for merchants to manually configure event providers, subscriptions, or environment variables.
+    - Requires [Admin UI SDK](https://developer.adobe.com/commerce/extensibility/admin-ui-sdk/) version 3.3.1 or later.
+    - Requires minimum library versions 1.0.0 or later for `@adobe/aio-commerce-lib-config`, `@adobe/aio-commerce-lib-app`, and `@adobe/aio-commerce-sdk`.
+    - Not currently supported for local Commerce installations — requires a hosted (cloud or on-premises) environment.
+
 - Script management
   - **Script validation**: Execute everything in `package.json` scripts section and ensure there are no errors.
   - **Script cleanup**: Ensure there are no unused or non-working scripts.


### PR DESCRIPTION
## Purpose of this pull request
This PR adds a new best practice section recommending the Adobe Commerce SDK family (`@adobe/aio-commerce-lib-*`) as the preferred approach over writing custom HTTP/auth/eventing logic, and adds guidance on using App Management to define configuration schema, event subscriptions, and Admin UI. Added per Ariel's request.

## Affected pages
- https://developer.adobe.com/commerce/extensibility/app-development/app-submission-guidelines 

whatsnew
Updated [App submission guidelines](https://developer.adobe.com/commerce/extensibility/app-development/app-submission-guidelines) to include Adobe Commerce SDK and Admin UI SDK 3.3.1.