### PR TITLE
Uncomment ACCS webhook

### DIFF
--- a/src/pages/webhooks/hooks.md
+++ b/src/pages/webhooks/hooks.md
@@ -392,7 +392,7 @@ Active: Yes
 
 To get the product custom options such as text field, text area, radio button, check box, or product quantity while adding the product to cart from the storefront or GraphQL API.
 
-<CodeBlock slots="heading, code" repeat="1" languages="XML, YAML" />
+<CodeBlock slots="heading, code" repeat="2" languages="XML, YAML" />
 
 ##### webhooks.xml (PaaS)
 
@@ -402,8 +402,6 @@ To get the product custom options such as text field, text area, radio button, c
     <field name="quantity"       source="context_quote_item_options.get_qty" />
 </fields>
 ```
-
-\<!--
 
 ##### Admin (SaaS)
 
@@ -415,8 +413,6 @@ Name: quantity
 Source: context_quote_item_options.get_qty
 Active: Yes
 ```
-
---\>
 
 ### Context headers
 


### PR DESCRIPTION
## Purpose of this pull request

The "product custom options" webhook field example was missing its Admin (SaaS) YAML sample — it was left commented out with `\<!--` / `--\>` markers instead of being rendered like every other example on the page. This uncomments it and updates the `CodeBlock` `repeat` count from `1` to `2` to match the PaaS/SaaS pair, consistent with the surrounding examples.

## Affected pages

- https://developer.adobe.com/commerce/extensibility/webhooks/hooks/