### PR TITLE
docs(app-management): align with latest aio-commerce-sdk release

### DIFF
--- a/src/pages/admin-ui-sdk/release-notes.md
+++ b/src/pages/admin-ui-sdk/release-notes.md
@@ -20,7 +20,7 @@ July 29, 2026
 
 ## Version 4.2.0
 
-Admin UI SDK 4.2.0 is available for Adobe Commerce on Cloud and on-premises (PaaS) version 2.4.8 and later. It is also available for Adobe Commerce as a Cloud Service (SaaS).
+Admin UI SDK 4.2.0 is available for Adobe Commerce as a Cloud Service (SaaS) and version 2.4.8 and later of Adobe Commerce on Cloud and on-premises (PaaS).
 
 ### Release date
 

--- a/src/pages/admin-ui-sdk/release-notes.md
+++ b/src/pages/admin-ui-sdk/release-notes.md
@@ -20,7 +20,7 @@ July 29, 2026
 
 ## Version 4.2.0
 
-Admin UI SDK 4.2.0 is available for Adobe Commerce on Cloud and on-premises (PaaS) version 2.4.8 and later. Support for Adobe Commerce as a Cloud Service (SaaS) will be available in the near future.
+Admin UI SDK 4.2.0 is available for Adobe Commerce on Cloud and on-premises (PaaS) version 2.4.8 and later. It is also available for Adobe Commerce as a Cloud Service (SaaS).
 
 ### Release date
 

--- a/src/pages/app-management/app-metadata.md
+++ b/src/pages/app-management/app-metadata.md
@@ -35,7 +35,7 @@ The metadata contains the following properties:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `id` | string | Yes | Unique identifier for your app. Must contain only alphanumeric characters and hyphens. |
+| `id` | string | Yes | Unique identifier for your app. Must contain only alphanumeric characters and hyphens. Maximum 100 characters. |
 | `displayName` | string | Yes | Name shown in the Admin UI. Maximum 50 characters. |
 | `description` | string | Yes | Brief description of your app's functionality. Maximum 255 characters. |
 | `version` | string | Yes | Semantic version number (for example, `1.0.0`, `2.1.3`). |

--- a/src/pages/app-management/build-deploy.md
+++ b/src/pages/app-management/build-deploy.md
@@ -20,9 +20,15 @@ The initialization process creates files organized by extension point:
 
 | File | Description |
 |------|-------------|
-| `src/commerce-extensibility-1/.generated/app.commerce.manifest.json` | Validated JSON representation of your app config |
+| `src/commerce-extensibility-1/.generated/app.commerce.manifest.json` | Validated JSON snapshot of your app config, generated only when the whole config can be represented as JSON |
+| `src/commerce-extensibility-1/.generated/app.commerce.config.js` | Generated module that the `#app.commerce.config` import alias resolves to |
 | `src/commerce-extensibility-1/.generated/actions/app-management/` | Runtime actions for app config and installation |
 | `src/commerce-extensibility-1/ext.config.yaml` | Extension manifest with `pre-app-build` hook |
+
+Import your app configuration through the `#app.commerce.config` alias. `generate` registers this alias in your project's `package.json` `imports` for every app (since `@adobe/aio-commerce-lib-app` 1.8.0), so your own runtime actions can import your config the same way the generated actions do, without referencing generated file paths. The alias resolves to the generated `app.commerce.config.js` module, which is built differently depending on whether your config is static or dynamic:
+
+* **Static (serializable) config**: the validated `app.commerce.manifest.json` snapshot is generated, and the module re-exports it.
+* **Dynamic config** (contains logic that can't be expressed as JSON, such as a `dynamicList` field with a function-based `options`): no manifest is generated, and the module is built directly from your `app.commerce.config` source file.
 
 **`commerce/configuration/1`** for Business configuration (when a `businessConfig` is defined).
 
@@ -41,14 +47,17 @@ The initialization process creates files organized by extension point:
 
 ## Generated runtime actions
 
-The libraries generate runtime actions organized by extension point. These are auto-generated directories and any manual changes can be lost during regeneration.
+The libraries generate runtime actions organized by extension point. These are auto-generated directories and any manual changes can be lost during regeneration. Generated runtime actions default to the `nodejs:24` App Builder runtime, and the CLI requires Node.js 22–24.
 
 ### App Management actions from `commerce/extensibility/1`
 
 | Action | Description |
 |--------|-------------|
 | `app-config` | Serves the app configuration to the App Management UI. |
-| `installation` | Drives the installation flow, including custom installation steps. |
+| `association` | Keeps track of which Commerce instance the app is associated with, so the app can identify and connect to it while installed; clears that record when the app is unassociated. |
+| `installation` | Drives the installation and uninstallation flow, including custom installation steps. |
+
+`generate` only creates the `installation` action when your config includes custom installation steps, Commerce or external events, webhooks, or `adminUi`.
 
 ### Business configuration actions from `commerce/configuration/1`
 

--- a/src/pages/app-management/build-deploy.md
+++ b/src/pages/app-management/build-deploy.md
@@ -25,7 +25,7 @@ The initialization process creates files organized by extension point:
 | `src/commerce-extensibility-1/.generated/actions/app-management/` | Runtime actions for app config and installation |
 | `src/commerce-extensibility-1/ext.config.yaml` | Extension manifest with `pre-app-build` hook |
 
-Import your app configuration through the `#app.commerce.config` alias. `generate` registers this alias in your project's `package.json` `imports` for every app (since `@adobe/aio-commerce-lib-app` 1.8.0), so your own runtime actions can import your config the same way the generated actions do, without referencing generated file paths. The alias resolves to the generated `app.commerce.config.js` module, which is built differently depending on whether your config is static or dynamic:
+Import your app configuration through the `#app.commerce.config` alias. The `generate` command registers this alias in your project's `package.json` `imports` for every app (since `@adobe/aio-commerce-lib-app` 1.8.0), so your own runtime actions can import your config the same way the generated actions do, without referencing generated file paths. The alias resolves to the generated `app.commerce.config.js` module, which is built differently depending on whether your config is static or dynamic:
 
 * **Static (serializable) config**: the validated `app.commerce.manifest.json` snapshot is generated, and the module re-exports it.
 * **Dynamic config** (contains logic that can't be expressed as JSON, such as a `dynamicList` field with a function-based `options`): no manifest is generated, and the module is built directly from your `app.commerce.config` source file.

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -73,7 +73,7 @@ This `businessConfig` schema contains the following properties:
 | `description` | string | No | Help text displayed below the field. |
 | `options` | array or function | Conditional | Required for `list` and `dynamicList`. For `list`, an array of `{ label, value }` objects. For `dynamicList`, an async function that receives runtime action `params` and returns that array. |
 | `selectionMode` | string | Conditional | Required for `list` and `dynamicList`. Set to `single` for standard dropdown or `multiple` to allow multiple selections. |
-| `env` | array | No | Limits the field to **PaaS** (`paas`) or **SaaS** (`saas`). To enable the field to all environments, omit the field or specify both values. |
+| `env` | array | No | Limits the field to **PaaS** (`paas`) or **SaaS** (`saas`). To enable the field in all environments, omit the property or specify both values. |
 
 ## Supported field types
 
@@ -221,7 +221,7 @@ After a scope is deleted in Commerce, run **Sync commerce scopes** again for eac
 
 ### Syncing scopes from a runtime action
 
-`getScopeTree`, `syncCommerceScopes`, `unsyncCommerceScopes`, and `setCustomScopeTree` from `@adobe/aio-commerce-lib-config` are callable SDK functions, not only the Admin UI actions behind **Sync commerce scopes**. Call them directly from your own runtime actions when you need to read or refresh the scope tree programmatically.
+The `@adobe/aio-commerce-lib-config` functions `getScopeTree`, `syncCommerceScopes`, `unsyncCommerceScopes`, and `setCustomScopeTree` are callable directly, not only through the Admin UI actions behind **Sync commerce scopes**. Call them from your own runtime actions when you need to read or refresh the scope tree programmatically.
 
 ## Schema requirements
 
@@ -343,7 +343,7 @@ async function main(params) {
 
 ### Global scope and selectors
 
-`getConfiguration`, `getConfigurationByKey`, and `setConfiguration` accept an **optional** scope selector. When you omit it, the library resolves the **global** scope.
+The `getConfiguration`, `getConfigurationByKey`, and `setConfiguration` functions accept an **optional** scope selector. When you omit it, the library resolves the **global** scope.
 
 ### Write configuration values
 

--- a/src/pages/app-management/configuration-schema.md
+++ b/src/pages/app-management/configuration-schema.md
@@ -87,7 +87,8 @@ The following field types are available for your `businessConfig` schema:
 | `tel` | string | Phone number input with format validation |
 | `url` | string | URL input with validation |
 | `list` | string | Dropdown with preconfigured options |
-| `dynamicList` | string | Dropdown with options resolved at runtime. Requires `@adobe/aio-commerce-lib-config` version **1.6.0** or later. See [Dynamic list fields](#dynamic-list-fields). |
+| `dynamicList` | string | Dropdown with options resolved at runtime. Requires `@adobe/aio-commerce-lib-config` version **1.5.0** or later. See [Dynamic list fields](#dynamic-list-fields). |
+| `boolean` | boolean | Toggle switch. Defaults to `false`. |
 
 ### Password field encryption
 
@@ -182,7 +183,7 @@ For fields that allow multiple selections, set `selectionMode` to `multiple` and
 
 ### Dynamic list fields
 
-Use `dynamicList` when dropdown options depend on data that is only available at runtime—for example, payment methods returned by an external API. The `options` property must be an async function that receives the runtime action `params` and returns an array of `{ label, value }` objects. You can set `default` to a function that receives the resolved options and returns the default value.
+Use `dynamicList` when dropdown options depend on data that is only available at runtime (for example, payment methods returned by an external API). The `options` property must be an async function that receives the runtime action `params` and returns an array of `{ label, value }` objects. You can set `default` to a function that receives the resolved options and returns the default value.
 
 ```js
 {
@@ -200,7 +201,7 @@ Use `dynamicList` when dropdown options depend on data that is only available at
 
 When your schema includes a `dynamicList` field, the `options` function may read values from runtime action inputs (such as API keys). Add those inputs to every action that calls `initialize`, including the generated `app-config` and `config` actions. See [Configure action inputs for dynamic lists](#configure-action-inputs-for-dynamic-lists).
 
-Because `dynamicList` options are resolved at runtime, `initialize` must be **awaited** and passed the action `params`. Import the schema from `app.commerce.config`; when your schema includes any `dynamicList` field, no `configuration-schema.json` file is generated because JSON cannot represent function values. See [Initialize with and without dynamic lists](#initialize-with-and-without-dynamic-lists).
+Because `dynamicList` options are resolved at runtime, `initialize` must be **awaited** and passed the action `params`. Import the schema from `app.commerce.config`; when your schema includes any `dynamicList` field, no `configuration-schema.json` file is generated because JSON cannot represent function values. See [Initialize configuration](#initialize-configuration).
 
 ## Scope tree synchronization
 
@@ -210,7 +211,7 @@ Apps with `businessConfig` use a scope tree (Global, Commerce websites, stores, 
 
 When you add, rename, or remove websites, stores, or store views in Adobe Commerce, App Management **does not** refresh the scope hierarchy by itself. Cached scope data is used until an Admin runs **Sync commerce scopes** for **that** application.
 
-If several apps are associated with the same instance—for example, ten apps that define business configuration—you must open **each** app in App Management and sync **individually**. From the application, open **Manage scopes**, open **Quick actions**, then choose **Sync commerce scopes**.
+If several apps are associated with the same instance (for example, ten apps that define business configuration), you must open **each** app in App Management and sync **individually**. From the application, open **Manage scopes**, open **Quick actions**, then choose **Sync commerce scopes**.
 
 ### Removing scopes
 
@@ -218,11 +219,15 @@ After a scope is deleted in Commerce, run **Sync commerce scopes** again for eac
 
 ![Manage Scopes Quick actions menu with Sync commerce scopes](../images/app-management/manage-scopes-sync-commerce-scopes.png)
 
+### Syncing scopes from a runtime action
+
+`getScopeTree`, `syncCommerceScopes`, `unsyncCommerceScopes`, and `setCustomScopeTree` from `@adobe/aio-commerce-lib-config` are callable SDK functions, not only the Admin UI actions behind **Sync commerce scopes**. Call them directly from your own runtime actions when you need to read or refresh the scope tree programmatically.
+
 ## Schema requirements
 
 Your `app.commerce.config` is validated each time you run a `generate` command (for example, `npx aio-commerce-lib-app generate all`). The schema validation checks for:
 
-* **Required properties**. Fields must have `name`, `label`, and `type`.
+* **Required properties**. Fields must have `name` and `type`. `label` is optional.
 * **Type-matched defaults**. Default values must match the field type (for example, a `text` field cannot have a `number` default).
 * **Encryption key for passwords**. If your schema contains password fields, configure an encryption key. See [Password field encryption](#password-field-encryption) for more information.
 
@@ -236,26 +241,9 @@ Every runtime action that calls `getConfiguration`, `getConfigurationByKey`, or 
 
 The schema is held in memory only for that invocation. If you omit `initialize`, those configuration functions throw errors. See [Initialization](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/docs/usage.md#initialization) in the configuration library usage guide.
 
-#### Initialize with and without dynamic lists
+#### Initialize configuration
 
-<Tab orientation="horizontal" slots="heading, content" repeat="2"/>
-
-### Without dynamicList
-
-When your schema has **no** `dynamicList` fields, call `initialize` synchronously at the start of the action. You can pass the schema from your root `app.commerce.config` file or from the generated `configuration-schema.json` file:
-
-```js
-import { initialize } from "@adobe/aio-commerce-lib-config";
-import schema from "path/to/your/generated/config-schema.json";
-
-export async function main(params) {
-  initialize({ schema });
-}
-```
-
-### With dynamicList
-
-When your schema includes a `dynamicList` field (requires `@adobe/aio-commerce-lib-config` version 1.6.0 or later), `options` and `default` are functions that run at runtime. Import the schema from `app.commerce.config`. No `configuration-schema.json` file is generated for schemas that include `dynamicList` fields—JSON cannot represent function values, so there is no generated file to import. Await `initialize` and pass the action `params`:
+See [Build and deploy](build-deploy.md#generated-files) for how the `#app.commerce.config` alias is generated. Import your schema from the alias and await `initialize`, passing the action `params`:
 
 ```js
 import { initialize } from "@adobe/aio-commerce-lib-config";
@@ -266,9 +254,7 @@ export async function main(params) {
 }
 ```
 
-<InlineAlert variant="info" slots="text"/>
-
-The `#app.commerce.config` import alias is currently available only when your schema includes `dynamicList` fields. Support for using this import without `dynamicList` may be added in a future library release.
+When your schema includes a `dynamicList` field (requires `@adobe/aio-commerce-lib-config` version **1.5.0** or later), its `options` and `default` are functions resolved at runtime from the `params` you pass to `initialize`.
 
 A **scope selector** tells the library which node in the scope tree to read or write. That tree can include **Adobe Commerce** scopes (such as websites and store views, each with a scope code and a **level** in the hierarchy), **custom scopes** you create in App Management (code only; see below), **global** scope, and other nodes that your app or merchants configure.
 
@@ -291,7 +277,7 @@ async function main(params) {
 }
 ```
 
-When your action receives Adobe Commerce **numeric IDs** (for example, from a REST API response), use `byWebsiteId`, `byStoreId`, or `byStoreViewId`. Each helper hard-codes its scope level so the same ID can target a website, store, or store view unambiguously.
+When your action receives Adobe Commerce **numeric IDs** (for example, from a REST API response), use `byWebsiteId`, `byStoreId`, or `byStoreViewId` (available since `@adobe/aio-commerce-lib-config` 1.5.0). Each helper hard-codes its scope level so the same ID can target a website, store, or store view unambiguously.
 
 ```js
 import {
@@ -339,13 +325,50 @@ async function main(params) {
 }
 ```
 
+When you already know a scope's unique ID (for example, from a previous `getScopeTree` call), use `byScopeId(scopeId)` to select it directly, regardless of scope type.
+
+```js
+import { initialize, getConfigurationByKey, byScopeId } from "@adobe/aio-commerce-lib-config";
+import appConfig from "#app.commerce.config";
+
+async function main(params) {
+  initialize({ schema: appConfig.businessConfig.schema });
+
+  const { config: { value: endpoint } } = await getConfigurationByKey(
+    "api-endpoint",
+    byScopeId(params.scope_id),
+  );
+}
+```
+
 ### Global scope and selectors
 
 `getConfiguration`, `getConfigurationByKey`, and `setConfiguration` accept an **optional** scope selector. When you omit it, the library resolves the **global** scope.
 
+### Write configuration values
+
+Use `setConfiguration` to persist configuration values for a scope. For `password` fields, pass `encryptionKey` in the options object; omitting it throws an error.
+
+```js
+import { initialize, setConfiguration, byCodeAndLevel } from "@adobe/aio-commerce-lib-config";
+import appConfig from "#app.commerce.config";
+
+async function main(params) {
+  initialize({ schema: appConfig.businessConfig.schema });
+
+  await setConfiguration(
+    { config: [{ name: "api-key", value: params.newApiKey }] },
+    byCodeAndLevel("default", "store_view"),
+    { encryptionKey: params.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY },
+  );
+}
+```
+
+The options object also supports a `cacheTimeout` (in seconds; defaults to `300`) to control how long a resolved configuration value is cached.
+
 ### Configure action inputs for dynamic lists
 
-When a `dynamicList` field reads runtime inputs (for example, `params.SOME_API_KEY`), declare those inputs on every action that calls `initialize`—including generated App Management actions and any custom runtime actions that use `@adobe/aio-commerce-lib-config`.
+When a `dynamicList` field reads runtime inputs (for example, `params.SOME_API_KEY`), declare those inputs on every action that calls `initialize`, including generated App Management actions and any custom runtime actions that use `@adobe/aio-commerce-lib-config`.
 
 <Tab orientation="horizontal" slots="heading, code" repeat="2"/>
 

--- a/src/pages/app-management/define-app.md
+++ b/src/pages/app-management/define-app.md
@@ -9,13 +9,13 @@ keywords:
 
 # Define your app
 
-The `app.commerce.config` file is the central configuration file for your App Builder application. It defines your app metadata, business configuration schema, and optional sections such as **[Events](installation/events.md)**, **[Webhooks](installation/webhooks.md)**, and **[Custom steps](installation/customize.md)**.
+The `app.commerce.config` file is the central configuration file for your App Builder application. It defines your app metadata, business configuration schema, and optional sections such as **[Events](installation/events.md)**, **[Webhooks](installation/webhooks.md)**, **[Custom steps](installation/customize.md)**, and **[Admin UI SDK](installation/admin-ui-sdk.md)**.
 
 Create an `app.commerce.config` file consisting of **[App metadata](app-metadata.md)** and **[Business configuration](configuration-schema.md)**.
 
 <InlineAlert variant="info" slots="text"/>
 
-The `app.commerce.config` file supports both JavaScript and TypeScript file types.
+The `app.commerce.config` file can be written in JavaScript or TypeScript. If both are present, the JavaScript file takes priority.
 
 ## Example
 
@@ -127,6 +127,13 @@ export default defineConfig({
         script: "./scripts/custom.js",
       },
     ],
+  },
+  adminUi: {
+    menu: {
+      id: "my_commerce_application_menu",
+      label: "My Commerce Application",
+      description: "Manage settings for My Commerce Application.",
+    },
   },
 });
 ```

--- a/src/pages/app-management/helpers.md
+++ b/src/pages/app-management/helpers.md
@@ -1,0 +1,239 @@
+---
+title: App Management helpers
+description: Use the helpers that @adobe/aio-commerce-lib-app provides to call the associated Adobe Commerce instance and publish configured I/O Events from App Builder runtime actions.
+keywords:
+  - App Builder
+  - App Management
+  - Extensibility
+  - Events
+---
+
+# App Management helpers
+
+Once an app is associated with an Adobe Commerce instance through App Management, `@adobe/aio-commerce-lib-app` exposes a set of helpers you can call from any runtime action: connecting to the associated Commerce instance, publishing a configured I/O Event, and handling the errors those helpers can throw. This page describes each helper and how to use it. You don't need custom storage or to thread parameters through every layer of the call stack.
+
+<InlineAlert variant="info" slots="text"/>
+
+Every helper on this page (`getCommerceInstance`, `getCommerceClient`, `publishEvent`, `resolveIoEventCode`, and the error classes in [Handle errors](#handle-errors)) is available since `@adobe/aio-commerce-lib-app` version 1.8.0.
+
+## Connect to the associated Commerce instance
+
+`@adobe/aio-commerce-lib-app` stores the Commerce instance an app is associated with, so any runtime action can retrieve it or call the Commerce API without custom storage.
+
+### How association is stored
+
+Every app generated with `@adobe/aio-commerce-lib-app` includes a standalone `association` runtime action alongside `app-config`. App Management calls it automatically during the association lifecycle: you don't call it yourself.
+
+* **During association**: stores the Commerce instance's `baseUrl` and `env` (`"saas"` or `"paas"`).
+* **During unassociation**: clears the stored data when the app.
+
+<InlineAlert variant="info" slots="text"/>
+
+Apps scaffolded before this feature shipped don't have the `association` action yet. After upgrading `@adobe/aio-commerce-lib-app`, run `npx aio-commerce-lib-app generate actions` (or `generate all`) and redeploy so the endpoint exists. A plain `aio app deploy` does not add it: the `pre-app-build` hook only regenerates actions already declared in `ext.config.yaml`. If the app was already associated under the older SDK, re-associate it after redeploying so the store call runs and backfills the instance data.
+
+Two helpers are exported from `@adobe/aio-commerce-lib-app` to read that stored data back:
+
+| Helper | Returns |
+|--------|---------|
+| `getCommerceClient(auth, fetchOptions?)` | A ready-to-use `AdobeCommerceHttpClient` for calling the Commerce API. |
+| `getCommerceInstance()` | The raw `{ baseUrl, env }` association data. |
+
+Both throw `AssociationRecordNotFoundError` if the app is not currently associated, was unassociated, or was associated by an older SDK that did not store this data. See [Handle errors](#handle-errors).
+
+### Get a ready-to-use client
+
+`getCommerceClient` builds the base URL and flavor from the stored association data; you supply the resolved IMS auth. App Management requires IMS, so `auth` accepts only IMS auth: resolve it with `resolveImsAuthParams` (available since `@adobe/aio-commerce-lib-auth` version 1.0.1) from `@adobe/aio-commerce-lib-auth`, or pass an `ImsAuthProvider` built with `getImsAuthProvider` or `forwardImsAuthProvider`. The optional `fetchOptions` ([ky](https://github.com/sindresorhus/ky#options) options such as `headers`, `timeout`, or `retry`) are forwarded to the underlying client.
+
+```js
+import { getCommerceClient } from "@adobe/aio-commerce-lib-app";
+import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
+
+export async function main(params) {
+  const client = await getCommerceClient(resolveImsAuthParams(params));
+  const products = await client.get("products").json();
+}
+```
+
+### Get the raw instance data
+
+Use `getCommerceInstance` when you only need the metadata: for example, for logging or to build a custom client.
+
+```js
+import { getCommerceInstance } from "@adobe/aio-commerce-lib-app";
+
+export async function main() {
+  const instance = await getCommerceInstance();
+
+  // instance.baseUrl: Commerce API base URL
+  // instance.env: "saas" | "paas"
+}
+```
+
+### Handle the unassociated state
+
+Wrap the call in `try`/`catch` to respond gracefully when the app isn't associated yet:
+
+```js
+import { badRequest, ok } from "@adobe/aio-commerce-lib-core/responses";
+import {
+  AssociationRecordNotFoundError,
+  getCommerceClient,
+} from "@adobe/aio-commerce-lib-app";
+import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
+
+export async function main(params) {
+  try {
+    const client = await getCommerceClient(resolveImsAuthParams(params));
+    return ok({ body: await client.get("products").json() });
+  } catch (error) {
+    if (error instanceof AssociationRecordNotFoundError) {
+      return badRequest({
+        body: { message: "App is not associated with a Commerce instance." },
+      });
+    }
+    throw error;
+  }
+}
+```
+
+## Publish a configured event
+
+Runtime actions can publish a custom I/O Event by referencing the provider and event exactly as declared in the `eventing` section of `app.commerce.config`. At installation time, the SDK writes each configured provider's I/O Events ID and event codes to system storage. `publishEvent` resolves those automatically by key and name and publishes the event.
+
+`publishEvent(params)` takes:
+
+| Property | Description |
+|----------|-------------|
+| `client` | An `AdobeIoEventsApiClient` (from `@adobe/aio-commerce-lib-events`) created with the IMS auth to use for the ingress call. |
+| `provider` | The `key` of an event provider declared in `app.commerce.config`. |
+| `event` | The `name` of an event declared under that provider. |
+| `payload` | The event payload: any JSON object. The SDK wraps it in a CloudEvents 1.0 envelope before sending. |
+
+<InlineAlert variant="info" slots="text"/>
+
+In general, prefer to use `publishEvent` for your app's own **external** events (declared under `eventing.external`). Adobe Commerce publishes its own Commerce events (declared under `eventing.commerce`) for you; your app subscribes to those with `runtimeActions` instead of publishing them.
+
+For example, declare an external provider with `key: "order-events"` and an event named `order.created` in `app.commerce.config` (see [Events](installation/events.md) and [Provider configuration](installation/events.md#provider-configuration)):
+
+```js
+import { defineConfig } from "@adobe/aio-commerce-lib-app/config";
+
+export default defineConfig({
+  metadata: {
+    // ...
+  },
+  eventing: {
+    external: [
+      {
+        provider: {
+          key: "order-events",
+          label: "Order Events",
+          description: "Events published when an order changes",
+        },
+        events: [
+          {
+            name: "order.created",
+            label: "Order Created",
+            description: "Triggered when a new order is created",
+            runtimeActions: ["my-package/handle-order-created"],
+          },
+        ],
+      },
+    ],
+  },
+});
+```
+
+A runtime action then publishes it by referencing the same `key` and event `name`:
+
+```js
+import { publishEvent } from "@adobe/aio-commerce-lib-app";
+import { createAdobeIoEventsApiClient } from "@adobe/aio-commerce-lib-events";
+import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
+
+export async function main(params) {
+  const client = createAdobeIoEventsApiClient({
+    auth: resolveImsAuthParams(params),
+    config: { ingressBaseUrl: params.AIO_EVENTS_INGRESS_BASE_URL },
+  });
+
+  await publishEvent({
+    client,
+    provider: "order-events",
+    event: "order.created",
+    payload: { orderId: "100000123", total: 149.99 },
+  });
+}
+```
+
+### Resolve an event's I/O Events code ahead of time
+
+`resolveIoEventCode(appId, eventName, providerType)` computes the same event code `publishEvent` sends, matching the prefixing rules used at installation time. This is useful when a caller needs to know an event's code in advance: for example, to match it against an incoming I/O Event.
+
+| Property | Description |
+|----------|-------------|
+| `appId` | The application's [`metadata.id`](app-metadata.md#metadata-properties), as declared in `app.commerce.config`. |
+| `eventName` | The `name` of the event, as declared in `app.commerce.config`. |
+| `providerType` | `"commerce"` or `"external"`, matching the section the event is declared under. |
+
+```js
+import { resolveIoEventCode } from "@adobe/aio-commerce-lib-app";
+
+resolveIoEventCode("my-app", "observer.order_placed", "commerce");
+// => "com.adobe.commerce.my_app.observer.order_placed"
+
+resolveIoEventCode("my-app", "webhook.received", "external");
+// => "my_app.webhook.received"
+```
+
+Instead of hardcoding `appId`, read it from the generated [`#app.commerce.config`](build-deploy.md#generated-files) import:
+
+```js
+import { resolveIoEventCode } from "@adobe/aio-commerce-lib-app";
+import appConfig from "#app.commerce.config";
+
+const eventCode = resolveIoEventCode(appConfig.metadata.id, "order.created", "external");
+```
+
+## Handle errors
+
+`@adobe/aio-commerce-lib-app` exports five typed error classes for the helpers on this page. `PublishEventError` is the base class for the three `publishEvent` errors, so you can catch it alone to handle any publish failure, or narrow with `instanceof` on the specific subclass.
+
+| Error | Thrown by | Trigger |
+|-------|-----------|---------|
+| `AssociationRecordNotFoundError` | `getCommerceInstance`, `getCommerceClient` | The app is not associated, was unassociated, or was associated by an older SDK that didn't store this data. Re-associate the app to resolve it. |
+| `PublishEventError` | `publishEvent` | Base class for the three errors below: catch this to handle any publish failure in one clause. |
+| `EventsDataNotInitializedError` | `publishEvent` | No eventing installation data is in system storage. The app installation hasn't run yet, or ran with an older SDK. Re-run the installation to initialize it. |
+| `ProviderNotFoundError` | `publishEvent` | The `provider` key doesn't match any provider declared in `app.commerce.config`. |
+| `EventNotFoundError` | `publishEvent` | The `event` name doesn't match any event declared under the given provider. |
+
+```js
+import {
+  EventNotFoundError,
+  EventsDataNotInitializedError,
+  ProviderNotFoundError,
+  PublishEventError,
+  publishEvent,
+} from "@adobe/aio-commerce-lib-app";
+
+try {
+  await publishEvent({ client, provider, event, payload });
+} catch (error) {
+  if (error instanceof EventsDataNotInitializedError) {
+    // The app installation hasn't run, or ran with an older SDK.
+  } else if (error instanceof ProviderNotFoundError) {
+    // The provider key doesn't match app.commerce.config.
+  } else if (error instanceof EventNotFoundError) {
+    // The event name doesn't match app.commerce.config.
+  } else if (error instanceof PublishEventError) {
+    // Any other publish-event failure.
+  } else {
+    throw error;
+  }
+}
+```
+
+## Related topics
+
+* [Events](installation/events.md): Declare the `eventing` provider and event configuration that `publishEvent` and `resolveIoEventCode` reference.
+* [Business configuration > Retrieve configuration at runtime](configuration-schema.md#retrieve-configuration-at-runtime): Read or write business configuration values from a runtime action.

--- a/src/pages/app-management/helpers.md
+++ b/src/pages/app-management/helpers.md
@@ -25,7 +25,7 @@ Every helper on this page (`getCommerceInstance`, `getCommerceClient`, `publishE
 Every app generated with `@adobe/aio-commerce-lib-app` includes a standalone `association` runtime action alongside `app-config`. App Management calls it automatically during the association lifecycle: you don't call it yourself.
 
 * **During association**: stores the Commerce instance's `baseUrl` and `env` (`"saas"` or `"paas"`).
-* **During unassociation**: clears the stored data when the app.
+* **During unassociation**: clears the stored data.
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -42,7 +42,7 @@ Both throw `AssociationRecordNotFoundError` if the app is not currently associat
 
 ### Get a ready-to-use client
 
-`getCommerceClient` builds the base URL and flavor from the stored association data; you supply the resolved IMS auth. App Management requires IMS, so `auth` accepts only IMS auth: resolve it with `resolveImsAuthParams` (available since `@adobe/aio-commerce-lib-auth` version 1.0.1) from `@adobe/aio-commerce-lib-auth`, or pass an `ImsAuthProvider` built with `getImsAuthProvider` or `forwardImsAuthProvider`. The optional `fetchOptions` ([ky](https://github.com/sindresorhus/ky#options) options such as `headers`, `timeout`, or `retry`) are forwarded to the underlying client.
+The `getCommerceClient` method builds the base URL and flavor from the stored association data; you supply the resolved IMS auth. App Management requires IMS, so the `auth` parameter accepts only IMS auth: resolve it with `resolveImsAuthParams` (available since `@adobe/aio-commerce-lib-auth` version 1.0.1) from `@adobe/aio-commerce-lib-auth`, or pass an `ImsAuthProvider` built with `getImsAuthProvider` or `forwardImsAuthProvider`. The optional `fetchOptions` ([ky](https://github.com/sindresorhus/ky#options) options such as `headers`, `timeout`, or `retry`) are forwarded to the underlying client.
 
 ```js
 import { getCommerceClient } from "@adobe/aio-commerce-lib-app";
@@ -98,9 +98,9 @@ export async function main(params) {
 
 ## Publish a configured event
 
-Runtime actions can publish a custom I/O Event by referencing the provider and event exactly as declared in the `eventing` section of `app.commerce.config`. At installation time, the SDK writes each configured provider's I/O Events ID and event codes to system storage. `publishEvent` resolves those automatically by key and name and publishes the event.
+Runtime actions can publish a custom I/O Event by referencing the provider and event exactly as declared in the `eventing` section of `app.commerce.config`. At installation time, the SDK writes each configured provider's I/O Events ID and event codes to system storage. The `publishEvent` function resolves those automatically by key and name, then publishes the event.
 
-`publishEvent(params)` takes:
+The `publishEvent(params)` function takes:
 
 | Property | Description |
 |----------|-------------|
@@ -168,7 +168,7 @@ export async function main(params) {
 
 ### Resolve an event's I/O Events code ahead of time
 
-`resolveIoEventCode(appId, eventName, providerType)` computes the same event code `publishEvent` sends, matching the prefixing rules used at installation time. This is useful when a caller needs to know an event's code in advance: for example, to match it against an incoming I/O Event.
+The `resolveIoEventCode(appId, eventName, providerType)` function computes the same event code that `publishEvent` sends, matching the prefixing rules used at installation time. This is useful when a caller needs to know an event's code in advance: for example, to match it against an incoming I/O Event.
 
 | Property | Description |
 |----------|-------------|

--- a/src/pages/app-management/index.md
+++ b/src/pages/app-management/index.md
@@ -31,7 +31,7 @@ The following diagram illustrates the workflow between app developers and app ma
 
 * **Unified lifecycle management**. Associate, configure, install, and unassociate apps from a single interface.
 
-* **List filters** — [Search and filter](build-deploy.md#find-an-application-in-the-admin) by app name, lifecycle **status**, and **extensibility pattern** (for example Events, or Webhooks) when many apps share your Adobe IMS organization.
+* **List filters**: [Search and filter](build-deploy.md#find-an-application-in-the-admin) by app name, lifecycle **status**, and **extensibility pattern** (for example Events, or Webhooks) when many apps share your Adobe IMS organization.
 
 ## Requirements
 
@@ -39,14 +39,17 @@ Before using App Management, ensure the following:
 
 * App Management is **not supported** for **local** Adobe Commerce installations at this time. Use a hosted Adobe Commerce environment (cloud or on-premises) where App Management is available in the Admin. See [Local Adobe Commerce instances](./troubleshooting.md#local-adobe-commerce-instances) for details.
 
-* [Admin UI SDK](../admin-ui-sdk/index.md) version 3.3.1, or greater, is required for App Management. [Verify your version](../admin-ui-sdk/installation.md#install-the-admin-ui-sdk) before proceeding.
+* [Admin UI SDK](../admin-ui-sdk/index.md) version 3.3.0, or greater, is required for the App Management view. [Verify your version](../admin-ui-sdk/installation.md#install-the-admin-ui-sdk) before proceeding.
+
+* Admin UI SDK menu entries, grid columns, mass actions, and order view buttons (the `adminUi` configuration) additionally require Admin UI SDK version 4.2.0 or greater.
 
 * App managers (Admin users) who associate apps must have the **App Management** permission enabled for their role under **Admin UI SDK** in **System** > **User Roles** > **Role Resources**. [Cannot access App Management (permissions)](./troubleshooting.md#cannot-access-app-management-permissions) describes how to set permissions.
 
 * App Builder applications with the following minimum library versions:
 
-  * `@adobe/aio-commerce-lib-config` version 1.0.0 or later.
-  * `@adobe/aio-commerce-lib-app` version 1.0.0 or later.
+  * `@adobe/aio-commerce-lib-config` version 1.0.0 or later, required only if the app defines business configuration.
+  * `@adobe/aio-commerce-lib-app` version 1.0.0 or later (some features may require newer versions).
+  * `@adobe/aio-commerce-lib-admin-ui` version 1.0.0 or later, required for working with the `commerce/backend-ui/2` Admin UI extension point.
   * `@adobe/aio-commerce-sdk` version 1.0.0 or later.
 
 * **Network connectivity to Adobe Commerce**. App Management requires connectivity to the Adobe Commerce instance you associate the app with. If that instance restricts inbound traffic with an IP allowlist, add the [Adobe I/O Runtime egress IPs](https://developer.adobe.com/app-builder/docs/guides/runtime_guides/security-general/#secure-communication-with-back-end-services) used by your app. See [Commerce instance behind an IP allowlist](./troubleshooting.md#commerce-instance-behind-an-ip-allowlist) for details.

--- a/src/pages/app-management/initialize-app.md
+++ b/src/pages/app-management/initialize-app.md
@@ -78,15 +78,23 @@ The initialization process:
 
 * Creates `app.commerce.config` with a template (prompts you to choose format and features if the file doesn't exist)
 * Installs required dependencies (`@adobe/aio-commerce-lib-app`, `@adobe/aio-commerce-sdk`, and `@adobe/aio-commerce-lib-config` when business configuration is enabled)
-* Adds a `postinstall` hook to `package.json`
 * Generates all required artifacts (`commerce/configuration/1` resources are only generated when `businessConfig` is defined)
 * Updates `app.config.yaml` and `install.yaml` with the appropriate extension references. Creates these files if they do not exist.
+* Adds a `postinstall` hook to `package.json`
+
+### Working with TypeScript
+
+Since `@adobe/aio-commerce-lib-app` 1.10.0, `init` supports TypeScript scaffolding. Using TypeScript in an App Management project requires the project's TypeScript build setup: a `webpack-config.cjs` file, a root `tsconfig.json`, and the `typescript` development dependency. If you scaffold a new project with a TypeScript config, `init` sets this up for you out of the box.
+
+If you're adding TypeScript to an existing project, re-run `init`. It's idempotent, so it adds any missing files or dependencies without touching your existing code. `init` only adds these files if they don't already exist, so any existing setup is preserved.
+
+See [Migrating an Existing Project to TypeScript](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-app/docs/usage.md#migrating-an-existing-project-to-typescript) if you already have these files or need to configure the TypeScript setup yourself.
 
 ## Initialize the configuration library in runtime actions
 
 When your app defines `businessConfig`, each App Builder runtime action that calls `getConfiguration`, `getConfigurationByKey`, or `setConfiguration` must run `initialize` before any of those three methods.
 
-If your schema includes `dynamicList` fields, you must **await** `initialize` and pass runtime action `params`. See [Initialize with and without dynamic lists](./configuration-schema.md#initialize-with-and-without-dynamic-lists) and [Configure action inputs for dynamic lists](./configuration-schema.md#configure-action-inputs-for-dynamic-lists).
+If your schema includes `dynamicList` fields, you must **await** `initialize` and pass runtime action `params`. See [Initialize configuration](./configuration-schema.md#initialize-configuration) and [Configure action inputs for dynamic lists](./configuration-schema.md#configure-action-inputs-for-dynamic-lists).
 
 See [Retrieve configuration at runtime](./configuration-schema.md#retrieve-configuration-at-runtime) for an example.
 

--- a/src/pages/app-management/initialize-app.md
+++ b/src/pages/app-management/initialize-app.md
@@ -41,7 +41,7 @@ Run the following command to set up your App Builder project:
 
 <InlineAlert variant="info" slots="text"/>
 
-Unlike the commands in [CLI commands](#cli-commands) below, `init` runs before the library is installed. At this point each package manager needs to use its fetch-and-run runner (`npx`, `yarn dlx`, `pnpm dlx`, `bun x`) rather than its `exec`-style equivalent, which only runs locally installed binaries. For the same reason, `init` references the library by its full registry name (`@adobe/aio-commerce-lib-app`), whereas later commands invoke the locally installed binary using the short name (`aio-commerce-lib-app`).
+Unlike the commands in [CLI commands](#cli-commands) below, the `init` command runs before the library is installed. At this point, each package manager needs to use its fetch-and-run runner (`npx`, `yarn dlx`, `pnpm dlx`, `bun x`) rather than its `exec`-style equivalent, which only runs locally installed binaries. For the same reason, this command references the library by its full registry name (`@adobe/aio-commerce-lib-app`), whereas later commands invoke the locally installed binary using the short name (`aio-commerce-lib-app`).
 
 <CodeBlock slots="heading, code" repeat="4" languages="BASH, BASH, BASH, BASH" />
 
@@ -84,9 +84,9 @@ The initialization process:
 
 ### Working with TypeScript
 
-Since `@adobe/aio-commerce-lib-app` 1.10.0, `init` supports TypeScript scaffolding. Using TypeScript in an App Management project requires the project's TypeScript build setup: a `webpack-config.cjs` file, a root `tsconfig.json`, and the `typescript` development dependency. If you scaffold a new project with a TypeScript config, `init` sets this up for you out of the box.
+As of version 1.10.0 of `@adobe/aio-commerce-lib-app`, the `init` command supports TypeScript scaffolding. Using TypeScript in an App Management project requires the project's TypeScript build setup: a `webpack-config.cjs` file, a root `tsconfig.json`, and the `typescript` development dependency. Scaffolding a new project with a TypeScript config sets this up for you out of the box.
 
-If you're adding TypeScript to an existing project, re-run `init`. It's idempotent, so it adds any missing files or dependencies without touching your existing code. `init` only adds these files if they don't already exist, so any existing setup is preserved.
+If you're adding TypeScript to an existing project, re-run `init`. It's idempotent: it only adds files and dependencies that don't already exist, so your existing setup and code are preserved.
 
 See [Migrating an Existing Project to TypeScript](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-app/docs/usage.md#migrating-an-existing-project-to-typescript) if you already have these files or need to configure the TypeScript setup yourself.
 
@@ -100,7 +100,7 @@ See [Retrieve configuration at runtime](./configuration-schema.md#retrieve-confi
 
 ## CLI commands
 
-The library provides the following CLI commands. Replace `npx` with your package manager of preference, using the below equivalents:
+The library provides the following CLI commands. Replace `npx` with your package manager of preference, using the equivalents below:
 
 * For [Yarn](https://yarnpkg.com/): `yarn exec`
 * For [PNPM](https://pnpm.io/): `pnpm exec`
@@ -108,7 +108,7 @@ The library provides the following CLI commands. Replace `npx` with your package
 
 | Command | Description |
 |---------|-------------|
-| `npx aio-commerce-lib-app generate all` | Generate all artifacts (manifest, schema, and runtime actions). If your schema contains password fields, configure an encryption key. An encryption key is generated when no encryption key is found.  See [Password field encryption](configuration-schema.md#password-field-encryption) for more information   |
+| `npx aio-commerce-lib-app generate all` | Generate all artifacts (manifest, schema, and runtime actions). If your schema contains password fields, configure an encryption key. An encryption key is generated when no encryption key is found. See [Password field encryption](configuration-schema.md#password-field-encryption) for more information. |
 | `npx aio-commerce-lib-app generate manifest` | Generate only the app manifest file |
 | `npx aio-commerce-lib-app generate actions` | Generate only runtime actions |
 | `npx aio-commerce-lib-app generate schema` | Generate only the configuration schema |

--- a/src/pages/app-management/installation/admin-ui-sdk.md
+++ b/src/pages/app-management/installation/admin-ui-sdk.md
@@ -21,6 +21,8 @@ At a high level, it is the top-level config block for declaring:
 
 Admin UI SDK V2 handles registration automatically. Unlike V1, there is no `registration` action to hand-author. `commerce/backend-ui/2` reads the registration directly from the generated `app-config` runtime action. When `adminUi` is defined, `init` and `generate all` automatically wire up the extension point, including the `pre-app-build` hook and the `workerProcess` declarations in `ext.config.yaml`. View-based features (a menu, a `view` mass action, or a `view` order view button) also get a minimal `web-src/` scaffold the first time they're added, using `.tsx` files for TypeScript configs and `.jsx` files otherwise.
 
+`adminUi` requires `@adobe/aio-commerce-lib-app` version 1.8.0 or later. Its schema (menu, grid columns, mass actions, order view buttons) became API-stable in version 1.9.0.
+
 For general Admin UI SDK concepts and extension points outside of App Management, see the [Admin UI SDK](../../admin-ui-sdk/index.md) documentation.
 
 ## Add a menu declaration
@@ -191,7 +193,7 @@ Mass actions are supported on `order`, `product`, and `customer`. The `id` is au
 | `runtimeAction` | | | x |
 | `timeout` | | | x |
 
-The `view` and `worker` variants are strict — setting `path` or `sandboxPermissions` on a `worker` action, or `runtimeAction` or `timeout` on a `view` action, fails validation.
+The `view` and `worker` variants are strict: setting `path` or `sandboxPermissions` on a `worker` action, or `runtimeAction` or `timeout` on a `view` action, fails validation.
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
@@ -228,7 +230,7 @@ Use `massActionErrorResponse(status, message)` to report a failure. See the [`@a
 
 ### View mass action page
 
-A `view` mass action opens an iframe at `path` inside your App Builder frontend — there's no server-side handler. Read the selected row IDs and close the iframe with the React hooks exported from `@adobe/aio-commerce-lib-admin-ui/web`:
+A `view` mass action opens an iframe at `path` inside your App Builder frontend. There's no server-side handler. Read the selected row IDs and close the iframe with the React hooks exported from `@adobe/aio-commerce-lib-admin-ui/web`:
 
 ```jsx
 import {
@@ -343,11 +345,14 @@ A `view` button opens an iframe at `<extension-host>/index.html<path>?orderId=<o
 ```jsx
 import { useHostConnection, useOrderViewButtonContext } from "@adobe/aio-commerce-lib-admin-ui/web";
 
-export function DeleteOrderPage() {
-  const { orderId } = useOrderViewButtonContext();
-  const { close } = useHostConnection();
+import { throwIfError } from "#web/utils.ts";
 
-  // ...delete orderId, then call close() to return to the order view.
+export function DeleteOrderPage() {
+  const { data } = throwIfError(useOrderViewButtonContext());
+  const { actions } = throwIfError(useHostConnection());
+  const { orderId } = data;
+
+  // ...delete orderId, then call actions.close() to return to the order view.
 }
 ```
 
@@ -396,7 +401,10 @@ import {
   AdminUiPermissionDeniedError,
   getAdminUiPermissionClient,
 } from "@adobe/aio-commerce-lib-admin-ui/api";
-import { getMassActionAclResourceId } from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
+import {
+  getMassActionAclResourceId,
+  massActionErrorResponse,
+} from "@adobe/aio-commerce-lib-admin-ui/mass-actions";
 
 import { getCommerceClient } from "@adobe/aio-commerce-lib-app";
 import { resolveImsAuthParams } from "@adobe/aio-commerce-lib-auth";
@@ -429,6 +437,6 @@ After changing `adminUi`, rebuild and deploy your app so the `pre-app-build` hoo
 
 ## Related documentation
 
-* [Admin UI SDK](../../admin-ui-sdk/index.md) — general Admin UI SDK concepts and extension points.
-* [`@adobe/aio-commerce-lib-admin-ui`](https://github.com/adobe/aio-commerce-sdk/tree/main/packages/aio-commerce-lib-admin-ui) — wire contract builders, menu constants, and the permission client used by `commerce/backend-ui/2` handlers.
-* [Build and deploy](../build-deploy.md) — generated files and runtime actions for `commerce/backend-ui/2`.
+* [Admin UI SDK](../../admin-ui-sdk/index.md): general Admin UI SDK concepts and extension points.
+* [`@adobe/aio-commerce-lib-admin-ui`](https://github.com/adobe/aio-commerce-sdk/tree/main/packages/aio-commerce-lib-admin-ui): wire contract builders, menu constants, and the permission client used by `commerce/backend-ui/2` handlers.
+* [Build and deploy](../build-deploy.md): generated files and runtime actions for `commerce/backend-ui/2`.

--- a/src/pages/app-management/installation/admin-ui-sdk.md
+++ b/src/pages/app-management/installation/admin-ui-sdk.md
@@ -19,9 +19,9 @@ At a high level, it is the top-level config block for declaring:
 * Mass actions
 * Order view buttons
 
-Admin UI SDK V2 handles registration automatically. Unlike V1, there is no `registration` action to hand-author. `commerce/backend-ui/2` reads the registration directly from the generated `app-config` runtime action. When `adminUi` is defined, `init` and `generate all` automatically wire up the extension point, including the `pre-app-build` hook and the `workerProcess` declarations in `ext.config.yaml`. View-based features (a menu, a `view` mass action, or a `view` order view button) also get a minimal `web-src/` scaffold the first time they're added, using `.tsx` files for TypeScript configs and `.jsx` files otherwise.
+Admin UI SDK V2 handles registration automatically. Unlike V1, there is no `registration` action to hand-author. `commerce/backend-ui/2` reads the registration directly from the generated `app-config` runtime action. When `adminUi` is defined, the `init` and `generate all` commands automatically wire up the extension point, including the `pre-app-build` hook and the `workerProcess` declarations in `ext.config.yaml`. View-based features (a menu, a `view` mass action, or a `view` order view button) also get a minimal `web-src/` scaffold the first time they're added, using `.tsx` files for TypeScript configs and `.jsx` files otherwise.
 
-`adminUi` requires `@adobe/aio-commerce-lib-app` version 1.8.0 or later. Its schema (menu, grid columns, mass actions, order view buttons) became API-stable in version 1.9.0.
+The `adminUi` config block requires `@adobe/aio-commerce-lib-app` version 1.8.0 or later. Its schema (menu, grid columns, mass actions, order view buttons) became API-stable in version 1.9.0.
 
 For general Admin UI SDK concepts and extension points outside of App Management, see the [Admin UI SDK](../../admin-ui-sdk/index.md) documentation.
 
@@ -62,7 +62,7 @@ export default defineConfig({
 
 ## Add grid columns
 
-You can add custom columns to order, product, or customer grids. Each grid's columns are fetched by a runtime action you implement; `generate` derives the `workerProcess` entry from `runtimeAction` automatically:
+You can add custom columns to order, product, or customer grids. Each grid's columns are fetched by a runtime action you implement. The `generate` command derives the `workerProcess` entry from `runtimeAction` automatically:
 
 ```js
 adminUi: {

--- a/src/pages/app-management/installation/customize.md
+++ b/src/pages/app-management/installation/customize.md
@@ -59,7 +59,7 @@ export default defineConfig({
         description: "Set up webhook endpoints for order notifications",
       },
       {
-        script: "./scripts/initialize-database.js",
+        script: "./scripts/initialize-database.ts",
         name: "Initialize Database",
         description: "Create required database tables and indexes",
       },
@@ -72,7 +72,7 @@ export default defineConfig({
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `script` | string | Yes | Path to the script file relative to your project root. |
+| `script` | string | Yes | Path to the script file relative to your project root. Must end with a `.js` or `.ts` extension. |
 | `name` | string | Yes | Display name for the installation step. Maximum 255 characters. |
 | `description` | string | No | Description of what the step does. Maximum 255 characters. |
 
@@ -80,9 +80,23 @@ export default defineConfig({
 
 Two custom installation steps cannot have the same name. Step names must be unique.
 
+### Working with TypeScript
+
+You can write custom installation step scripts as `.ts` files instead of `.js` once your project has the TypeScript build setup in place. See [Working with TypeScript](../initialize-app.md#working-with-typescript) for details.
+
 ### Writing installation scripts
 
-Your custom installation scripts must export a default function using `defineCustomInstallationStep`:
+Your custom installation scripts must export a default value using `defineCustomInstallationStep`. It accepts either a plain handler function (install only) or an object with `install` and optional `uninstall` handlers.
+
+The `context` passed to each handler exposes:
+
+| Property | Description |
+|----------|--------------|
+| `appData` | Credentials of the app being managed. |
+| `params` | Raw action parameters from the App Builder runtime action. |
+| `logger` | Logger instance for workflow logging. |
+
+#### Plain function form
 
 ```js
 import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
@@ -103,6 +117,28 @@ export default defineCustomInstallationStep(async (config, context) => {
   };
 });
 ```
+
+#### Object form with install and uninstall
+
+Use the object form when your step needs to clean up resources it created when the app is uninstalled:
+
+```js
+import { defineCustomInstallationStep } from "@adobe/aio-commerce-lib-app/management";
+
+export default defineCustomInstallationStep({
+  install: async (config, context) => {
+    context.logger.info(`Registering ${config.metadata.displayName}...`);
+    return { status: "success" };
+  },
+  uninstall: async (config, context) => {
+    context.logger.info(`Removing ${config.metadata.displayName}...`);
+  },
+});
+```
+
+<InlineAlert variant="info" slots="text"/>
+
+On uninstall, steps run in the **same declared order as install**, not reversed. Steps without an `uninstall` handler are silently skipped during uninstallation.
 
 ### Script with error handling
 
@@ -140,8 +176,8 @@ export default defineCustomInstallationStep(async (config, context) => {
 
 ### Script requirements
 
-* Scripts **must** use `export default` to export the main function.
-* Scripts are executed **sequentially** in the order defined.
+* Scripts **must** use `export default` to export either a handler function or an object with `install`/`uninstall` handlers.
+* Scripts are executed **sequentially** in the order defined, for both installation and uninstallation (uninstall does **not** reverse the order).
 * If any script throws an error, the installation fails and subsequent scripts are not executed.
 * Scripts have access to the complete app configuration.
 

--- a/src/pages/app-management/installation/customize.md
+++ b/src/pages/app-management/installation/customize.md
@@ -181,4 +181,4 @@ export default defineCustomInstallationStep(async (config, context) => {
 * If any script throws an error, the installation fails and subsequent scripts are not executed.
 * Scripts have access to the complete app configuration.
 
-After you modify custom installation scripts, you must manually run the `npx aio-commerce-lib-app` generate actions command before building and deploying. This ensures the installation action picks up your changes. For all other `app.commerce.config` updates, build and deploy alone is sufficient, as artifacts are regenerated during pre-app-build.
+After you modify custom installation scripts, you must manually run the `npx aio-commerce-lib-app generate actions` command before building and deploying. This ensures the installation action picks up your changes. For all other `app.commerce.config` updates, build and deploy alone is sufficient, as artifacts are regenerated during pre-app-build.

--- a/src/pages/app-management/installation/events.md
+++ b/src/pages/app-management/installation/events.md
@@ -80,9 +80,9 @@ export default defineConfig({
 | `runtimeActions` | array | Yes | Array of runtime actions to invoke (format: `package/action`). |
 | `destination` | string | No | Destination for the event. Must be a valid destination name. |
 | `env` | array | No | Restricts the event to **PaaS** (`paas`) and/or **SaaS** (`saas`). Omit or specify both to apply to all environments. |
-| `hipaa_audit_required` | boolean | No | Indicates if the event requires HIPAA audit. |
-| `priority` | boolean | No | Indicates if the event is prioritary. |
-| `force` | boolean | No | Indicates if the event should be forced. |
+| `hipaa_audit_required` | boolean | No | Indicates whether the event requires HIPAA audit. |
+| `priority` | boolean | No | Indicates whether the event is high priority. |
+| `force` | boolean | No | Indicates whether the event should be forced. |
 
 ### Event rules
 
@@ -128,7 +128,7 @@ eventing: {
 | `description` | string | Yes | Description of the event. Maximum 255 characters. |
 | `runtimeActions` | array | Yes | Array of runtime actions to invoke. |
 | `env` | array | No | Restricts the event to **PaaS** (`paas`) and/or **SaaS** (`saas`). Omit or specify both to apply to all environments. |
-| `hipaa_audit_required` | boolean | No | Indicates if the event requires HIPAA audit. |
+| `hipaa_audit_required` | boolean | No | Indicates whether the event requires HIPAA audit. |
 
 ## Provider configuration
 

--- a/src/pages/app-management/installation/events.md
+++ b/src/pages/app-management/installation/events.md
@@ -36,6 +36,7 @@ export default defineConfig({
         events: [
           {
             name: "plugin.order_placed",
+            label: "Order Placed",
             fields: [
               { name: "order_id" },
               { name: "customer_id" },
@@ -45,6 +46,7 @@ export default defineConfig({
           },
           {
             name: "observer.catalog_product_save_after",
+            label: "Product Price Updated",
             fields: [
               { name: "price" },
               { name: "sku" },
@@ -71,14 +73,15 @@ export default defineConfig({
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `name` | string | Yes | Event name. Must start with `plugin.` or `observer.` followed by lowercase letters and underscores. |
-| `label` | string | No | Display name for the event. Maximum 100 characters. |
-| `description` | string | No | Description of the event. Maximum 255 characters. |
-| `fields` | array | No | Array of field objects with `name` (required) and `source` (optional) properties. |
+| `label` | string | Yes | Display name for the event. Maximum 100 characters. |
+| `description` | string | Yes | Description of the event. Maximum 255 characters. |
+| `fields` | array | Yes | Array of field objects with `name` (required) and `source` (optional) properties. |
 | `rules` | array | No | Array of filtering rules. See [Event rules](#event-rules). |
 | `runtimeActions` | array | Yes | Array of runtime actions to invoke (format: `package/action`). |
 | `destination` | string | No | Destination for the event. Must be a valid destination name. |
-| `hipaaAuditRequired` | boolean | No | Indicates if the event requires HIPAA audit. |
-| `prioritary` | boolean | No | Indicates if the event is prioritary. |
+| `env` | array | No | Restricts the event to **PaaS** (`paas`) and/or **SaaS** (`saas`). Omit or specify both to apply to all environments. |
+| `hipaa_audit_required` | boolean | No | Indicates if the event requires HIPAA audit. |
+| `priority` | boolean | No | Indicates if the event is prioritary. |
 | `force` | boolean | No | Indicates if the event should be forced. |
 
 ### Event rules
@@ -122,8 +125,10 @@ eventing: {
 |----------|------|----------|-------------|
 | `name` | string | Yes | Event name. Word characters, hyphens, underscores, and dots allowed. |
 | `label` | string | Yes | Display name for the event. Maximum 100 characters. |
-| `description` | string | No | Description of the event. Maximum 255 characters. |
+| `description` | string | Yes | Description of the event. Maximum 255 characters. |
 | `runtimeActions` | array | Yes | Array of runtime actions to invoke. |
+| `env` | array | No | Restricts the event to **PaaS** (`paas`) and/or **SaaS** (`saas`). Omit or specify both to apply to all environments. |
+| `hipaa_audit_required` | boolean | No | Indicates if the event requires HIPAA audit. |
 
 ## Provider configuration
 
@@ -132,9 +137,9 @@ Both commerce and external event sources require a provider configuration:
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `label` | string | Yes | Display name for the provider. Maximum 100 characters. |
-| `description` | string | No | Description of the provider. Maximum 255 characters. |
+| `description` | string | Yes | Description of the provider. Maximum 255 characters. |
 | `key` | string | No | Optional unique key for the provider. Maximum 50 characters, alphanumeric with hyphens. |
 
 ## Related topics
 
-[Webhooks](webhooks.md) — Learn how to declare Commerce webhook subscriptions in `app.commerce.config` for App Management
+[Webhooks](webhooks.md): Learn how to declare Commerce webhook subscriptions in `app.commerce.config` for App Management

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -37,6 +37,7 @@ Each webhook entry uses the following properties:
 | `label` | string | Yes | Display label in App Management. |
 | `description` | string | Yes | Description shown in App Management. |
 | `category` | string | No | Used for webhook conflict resolution when multiple apps are using the same webhooks. Possible values are one of `validation`, `append`, or `modification`. |
+| `env` | array | No | Restricts the webhook to **PaaS** (`paas`) and/or **SaaS** (`saas`). Omit or specify both to apply to all environments. |
 | `runtimeAction` | string | Conditional | Required when not using an explicit `url` in `webhook`. Runtime action that resolves the webhook URL. |
 | `requireAdobeAuth` | boolean | No | When using `runtimeAction`, indicates whether Adobe authentication is required. Must match the `require-adobe-auth` setting for that runtime action in `app.config.yaml`. |
 | `webhook` | object | Yes | Webhook method, hook identity, HTTP method, and optional fields, rules, headers, timeouts, and either a `url` or no `url` (if `runtimeAction` is set). |
@@ -152,6 +153,6 @@ When your runtime action **handles** the HTTP callback from Commerce, you build 
 
 ## Related documentation
 
-* [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) (Experience League) — user guide for App Management in the Admin.
-* [Adobe Commerce Webhooks](../../webhooks/index.md) — product concepts and Admin behavior.
-* [Webhook responses](../../webhooks/responses.md) — operation types for handler actions.
+* [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) (Experience League): user guide for App Management in the Admin.
+* [Adobe Commerce Webhooks](../../webhooks/index.md): product concepts and Admin behavior.
+* [Webhook responses](../../webhooks/responses.md): operation types for handler actions.

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -61,10 +61,10 @@ The `webhook` object contains the following properties:
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `webhook_method` | string | Yes | Commerce webhook method (for example, `observer.catalog_product_save_after`). |
-| `webhook_type` | string | Yes | Typically `before` or `after` the original action. |
+| `webhook_type` | string | Yes | Must be `before` or `after`. |
 | `batch_name` | string | Yes | Batch identifier. Letters, numbers, and underscores only. |
 | `hook_name` | string | Yes | Hook identifier within the batch. Same character rules as `batch_name`. |
-| `method` | string | Yes | HTTP method for the outbound request (for example, `POST`). |
+| `method` | string | Yes | HTTP method for the outbound request. Must be `POST`, `PUT`, `DELETE`, or `GET`. |
 | `url` | string | Conditional | Absolute HTTPS URL. Required when the entry does **not** use `runtimeAction`. Omit when using `runtimeAction`. |
 | `batch_order` | number | No | Positive number; order among batches. |
 | `priority` | number | No | Positive priority hint. |

--- a/src/pages/app-management/installation/webhooks.md
+++ b/src/pages/app-management/installation/webhooks.md
@@ -19,7 +19,7 @@ Use [Events](./events.md) and webhooks when you need both asynchronous event del
 Webhook configuration spans both the developer who ships the app and the merchant who associates it with Commerce:
 
 * **App developers** declare webhooks in the `webhooks` field of `app.commerce.config`. That manifest is what App Management uses to know which webhook subscriptions belong to your app.
-* **Merchants** usually get webhooks from that manifest without extra setup. See [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps)  for more information on how to configure Adobe Commerce.
+* **Merchants** usually get webhooks from that manifest without extra setup. See [Install and access App Management](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#access-app-management) and [Commerce webhooks and apps](https://experienceleague.adobe.com/en/docs/commerce/app-management/install#commerce-webhooks-and-apps) for more information on how to configure Adobe Commerce.
 
 ## Webhook entries
 
@@ -27,7 +27,7 @@ Add a `webhooks` array at the top level of `defineConfig`. When present, it must
 
 Each entry must use **one** of these patterns (not both):
 
-* **`runtimeAction`**. No `url` inside `webhook`. The runtime action (format `package/action`) supplies the webhook URL at runtime. Optional `requireAdobeAuth` controls Adobe auth on that resolution path.
+* **`runtimeAction`**. No `url` inside `webhook`. The runtime action (format `package/action`) supplies the webhook URL at runtime. The optional `requireAdobeAuth` property controls Adobe auth on that resolution path.
 * **Explicit `url`**. The nested `webhook` object includes a valid absolute `https` URL. Do not set `runtimeAction` on the entry, or your configuration will be flagged as invalid.
 
 Each webhook entry uses the following properties:
@@ -44,15 +44,15 @@ Each webhook entry uses the following properties:
 
 ### Webhook category property
 
-Webhooks are divided into 3 categories (from lower to higher when it comes to possible conflicts with other applications):
+Webhooks are divided into three categories, ordered from lowest to highest potential for conflicts with other applications:
 
-* `validation` - Webhook is used only for validation purposes, returns only `success` or `validation` operations.
-* `append` - Webhook only appends data to the result and does not modify existing data. For example, add a shipping method on the checkout page.
-* `modification` - Webhook modifies the Commerce data with `add`, `replace`, and `remove` operations.
+* `validation`: Used only for validation purposes; returns only `success` or `validation` operations.
+* `append`: Appends data to the result without modifying existing data. For example, adding a shipping method on the checkout page.
+* `modification`: Modifies Commerce data with `add`, `replace`, and `remove` operations.
 
 <InlineAlert variant="warning" slots="text"/>
 
-If you're not sure which `category` to choose between `append` and `modification`, use `modification`. Keep in mind that it will not stop the app from install if there are possible conflicts, it only warns the user before install.
+If you're not sure whether to choose `append` or `modification`, use `modification`. Choosing the wrong category doesn't block installation when there are possible conflicts; it only warns the user before install.
 
 ### Nested `webhook` object
 

--- a/src/pages/app-management/purchase-approval-app.md
+++ b/src/pages/app-management/purchase-approval-app.md
@@ -24,15 +24,15 @@ This code is provided as a learning reference. It is not production-ready and sh
 
 The app shows how a single App Builder application can participate in the entire lifecycle of a business scenario:
 
-* **Install and configure** — The app is installed from Adobe Exchange, associated with a Commerce instance in the App Management view, and configured through the auto-generated Admin UI. No custom configuration UI code is required.
+* **Install and configure**: The app is installed from Adobe Exchange, associated with a Commerce instance in the App Management view, and configured through the auto-generated Admin UI. No custom configuration UI code is required.
 
-* **Checkout evaluation** — At checkout, Commerce calls the app through a webhook to evaluate the approval policy in real time and flag orders that require approval.
+* **Checkout evaluation**: At checkout, Commerce calls the app through a webhook to evaluate the approval policy in real time and flag orders that require approval.
 
-* **Event-driven workflow** — When an order is placed, Commerce emits an order event. For orders at or above the configured approval threshold, the app's event handler creates an approval request in an App Builder database.
+* **Event-driven workflow**: When an order is placed, Commerce emits an order event. For orders at or above the configured approval threshold, the app's event handler creates an approval request in an App Builder database.
 
-* **Approver dashboard** — A lightweight single-page app (React + Adobe Spectrum), surfaced through the Admin UI SDK, allows finance or procurement reviewers to list pending approvals and approve or reject orders.
+* **Approver dashboard**: A lightweight single-page app (React + Adobe Spectrum), surfaced through the Admin UI SDK, allows finance or procurement reviewers to list pending approvals and approve or reject orders.
 
-* **Observability** — An execution log, stored alongside the approval requests in the App Builder database, records webhook and event-handler invocations for troubleshooting.
+* **Observability**: An execution log, stored alongside the approval requests in the App Builder database, records webhook and event-handler invocations for troubleshooting.
 
 ## Prerequisites
 
@@ -43,12 +43,12 @@ The app shows how a single App Builder application can participate in the entire
   * **Adobe I/O Events for Adobe Commerce**
   * **App Builder Data Services** (backs the App Builder database used for approval requests and the execution log)
 
-* [Admin UI SDK](../admin-ui-sdk/index.md) 4.2.0 or greater, enabled and configured — required for the `commerce/backend-ui/2` extension point.
-* Adobe Commerce 2.4.5 or later, on either Adobe Commerce as a Cloud Service (SaaS) or Adobe Commerce on Cloud/on-premises (PaaS). In both cases, the app authenticates to Commerce with Adobe IMS with `@adobe/aio-commerce-lib-auth`. As a result, no Commerce integration (OAuth1) credentials are required. The checkout webhook is secured as follows:
+* [Admin UI SDK](../admin-ui-sdk/index.md) 4.2.0 or greater, enabled and configured. It powers the `commerce/backend-ui/2` extension point behind the approver dashboard, and is supported on Adobe Commerce as a Cloud Service (SaaS) and on Adobe Commerce on-premises and Cloud (PaaS) 2.4.8 or later.
+* Adobe Commerce 2.4.5 or later for the checkout webhook and order-placed event subscription, on either Adobe Commerce as a Cloud Service (SaaS) or Adobe Commerce on Cloud/on-premises (PaaS). In both cases, the app authenticates to Commerce with Adobe IMS with `@adobe/aio-commerce-lib-auth`. As a result, no Commerce integration (OAuth1) credentials are required. The checkout webhook is secured as follows:
   * **SaaS:** the webhook uses Adobe IMS authentication (`require-adobe-auth`), so Commerce authenticates to the runtime action automatically. No extra setup is required.
   * **PaaS:** `require-adobe-auth` is not available, so configure the webhook's authorization as described in [Checkout webhook](#checkout-webhook).
 * On PaaS only, the Commerce webhooks module and the Adobe I/O Events for Commerce module must be enabled. They are required for the checkout webhook and the order-placed event subscription. These modules are enabled automatically on Adobe Commerce as a Cloud Service.
-* Node.js 24 or later.
+* Node.js 22–24.
 
 ## Extension points
 
@@ -68,10 +68,10 @@ The following sections describe the app's pieces and how they work together to i
 
 The app is defined with [`@adobe/aio-commerce-lib-app`](./index.md#sdk-libraries) and [`@adobe/aio-commerce-lib-config`](./index.md#sdk-libraries). The configuration schema in `app.commerce.config.ts` drives the auto-generated [business configuration](./configuration-schema.md) form, where an app manager sets:
 
-* **Approval threshold amount** — orders at or above this value require approval.
-* **Currency code** — for example, `USD`.
-* **Approver emails** — a comma-separated list for reference.
-* **Approval message** — added to the order as a comment when the checkout webhook holds an order.
+* **Approval threshold amount**: orders at or above this value require approval.
+* **Currency code**: for example, `USD`.
+* **Approver emails**: a comma-separated list for reference.
+* **Approval message**: added to the order as a comment when the checkout webhook holds an order.
 
 For the general install-and-associate flow, see [Installation](./installation/index.md).
 

--- a/src/pages/app-management/purchase-approval-app.md
+++ b/src/pages/app-management/purchase-approval-app.md
@@ -16,7 +16,7 @@ The **Purchase Approval** app is a complete, end-to-end App Builder reference ap
 
 Use it as a starting point or as a reference for how these components fit together. See [Get the code](#get-the-code) for the source repository and setup steps.
 
-<InlineAlert variant="info" slots="text" />
+<InlineAlert variant="info" slots="text"/>
 
 This code is provided as a learning reference. It is not production-ready and should not be deployed as-is in a production environment without further review of security, performance, and error handling.
 

--- a/src/pages/app-management/release-notes.md
+++ b/src/pages/app-management/release-notes.md
@@ -12,5 +12,8 @@ keywords:
 Check GitHub releases for the latest updates about the main libraries used by App Management.
 
 * [@adobe/aio-commerce-sdk](https://github.com/adobe/aio-commerce-sdk/releases)
-* [@adobe/aio-commerce-lib-config](https://github.com/adobe/aio-commerce-sdk/tree/main/packages/aio-commerce-lib-config)
-* [@adobe/aio-commerce-lib-app](https://github.com/adobe/aio-commerce-sdk/tree/main/packages/aio-commerce-lib-app)
+* [@adobe/aio-commerce-lib-config](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-config/CHANGELOG.md)
+* [@adobe/aio-commerce-lib-app](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-app/CHANGELOG.md)
+* [@adobe/aio-commerce-lib-admin-ui](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-admin-ui/CHANGELOG.md)
+* [@adobe/aio-commerce-lib-events](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-events/CHANGELOG.md)
+* [@adobe/aio-commerce-lib-webhooks](https://github.com/adobe/aio-commerce-sdk/blob/main/packages/aio-commerce-lib-webhooks/CHANGELOG.md)

--- a/src/pages/app-management/troubleshooting.md
+++ b/src/pages/app-management/troubleshooting.md
@@ -42,7 +42,7 @@ Schema not initialized. Call `initialize({ schema })` before using configuration
 
 See [Retrieve configuration at runtime](./configuration-schema.md#retrieve-configuration-at-runtime) for an example.
 
-If your `businessConfig` schema uses `dynamicList` fields, `initialize` also needs `params` to resolve the list options at runtime. Omitting `params` produces:
+If your `businessConfig` schema uses `dynamicList` fields, the `initialize` call also needs `params` to resolve the list options at runtime. Omitting `params` produces:
 
 ```text
 Dynamic list options require runtime params. Call `initialize({ schema, params })` to resolve them.
@@ -193,7 +193,7 @@ Pass `encryptionKey: params.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` whenever you cal
 
 ### Generate an encryption key
 
-Run the command below to ensure `AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` is present in `.env`. If a key already exists, `encryption setup` leaves it unchanged.
+Run the command below to ensure `AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` is present in `.env`. If a key already exists, the `encryption setup` command leaves it unchanged.
 
 If `.env` was removed or has no key, the command generates a **new** key. That new key cannot decrypt configuration that was encrypted with an older key. If that happens, see [Failed to decrypt configuration](#failed-to-decrypt-configuration-re-association-or-configuration-page) for more information.
 
@@ -225,7 +225,7 @@ bun x aio-commerce-lib-config encryption setup
 
 ### Validate your encryption key configuration
 
-If it's already there, validate it has the expected format:
+If it's already there, validate that it has the expected format:
 
 <CodeBlock slots="heading, code" repeat="4" languages="BASH, BASH, BASH, BASH" />
 

--- a/src/pages/app-management/troubleshooting.md
+++ b/src/pages/app-management/troubleshooting.md
@@ -37,10 +37,16 @@ When your app defines `businessConfig`, each App Builder runtime action that cal
 An error message appears when you do not call `initialize` before any of those three methods:
 
 ```text
-Schema not initialized. Call initialize({ schema }) before using configuration functions.
+Schema not initialized. Call `initialize({ schema })` before using configuration functions.
 ```
 
 See [Retrieve configuration at runtime](./configuration-schema.md#retrieve-configuration-at-runtime) for an example.
+
+If your `businessConfig` schema uses `dynamicList` fields, `initialize` also needs `params` to resolve the list options at runtime. Omitting `params` produces:
+
+```text
+Dynamic list options require runtime params. Call `initialize({ schema, params })` to resolve them.
+```
 
 ## Local Adobe Commerce instances
 
@@ -58,7 +64,7 @@ aio runtime ip-list get
 
 See [Secure communication with back-end services](https://developer.adobe.com/app-builder/docs/guides/runtime_guides/security-general/#secure-communication-with-back-end-services) in the App Builder documentation for the full process, including the one-time terms acceptance and contact email prompt.
 
-Because this must be configured on the Commerce instance itself, only a Commerce administrator can apply the change—not the App Builder application owner.
+Because this must be configured on the Commerce instance itself, only a Commerce administrator can apply the change, not the App Builder application owner.
 
 ## Commerce instance behind HTTP authentication
 
@@ -68,7 +74,7 @@ Plan network and access controls so Commerce endpoints required by App Managemen
 
 ## Scope tree synchronization issues
 
-If new websites, stores, or store views exist in Commerce but **Manage scopes** in App Management looks stale—or scopes removed in Commerce still appear—the scope tree is almost certainly **out of date**.
+If new websites, stores, or store views exist in Commerce but **Manage scopes** in App Management looks stale (or scopes removed in Commerce still appear), the scope tree is almost certainly **out of date**.
 
 Scope hierarchy in App Management is **cached**. Changes to Commerce websites, stores, or store views **do not** sync automatically.
 
@@ -80,7 +86,7 @@ For full behavior and UI context, see [Scope tree synchronization](configuration
 
 `app.commerce.config` is validated against its schema every time the config is loaded. This happens during the `postinstall` and `pre-app-build` hooks, and whenever you run an `npx aio-commerce-lib-app generate …` command manually. If validation fails, check:
 
-1. **Required properties**. Fields must have `name`, `label`, and `type`.
+1. **Required properties**. Fields must have `name` and `type`. `label` is optional.
 
 1. **Type-matched defaults**. Default values must match the field type.
 
@@ -112,7 +118,7 @@ This message refers to the **App Management** association flow, not general Adob
 
 ### Develop or maintain the application
 
-1. Adobe Commerce treats an app as compatible with the association flow when the deployed package exposes the manifest and App Management runtime actions produced from **`app.commerce.config`**—specifically including valid **`metadata`**—by **`@adobe/aio-commerce-lib-app`**. Generic App Builder projects are not sufficient without that library-driven definition and generation step.
+1. Adobe Commerce treats an app as compatible with the association flow when the deployed package exposes the manifest and App Management runtime actions produced from **`app.commerce.config`** (specifically including valid **`metadata`**) by **`@adobe/aio-commerce-lib-app`**. Generic App Builder projects are not sufficient without that library-driven definition and generation step.
 
 1. Add the [SDK libraries](index.md#sdk-libraries), maintain a root [`app.commerce.config`](define-app.md) with [`metadata`](app-metadata.md) (and other sections as needed), run generators so `.generated` artifacts exist, then build and deploy. See [Initialize your app](initialize-app.md) and [Define your configuration schema](configuration-schema.md) for more information.
 
@@ -135,7 +141,7 @@ This message refers to the **App Management** association flow, not general Adob
 
 ### Runtime actions
 
-Code generation is a mandatory step for App Management to work. The `pre-app-build` hook only regenerates the commerce app manifest (a snapshot of your config), and the configuration schema, so runtime actions must be generated manually with the following command (idempotent):
+The `pre-app-build` hook regenerates the manifest, schema, and runtime actions under `.generated` automatically, so a regular `aio app build` keeps them in sync. When debugging, you can run the following command manually to refresh generated files without a full build (idempotent):
 
 <CodeBlock slots="heading, code" repeat="4" languages="BASH, BASH, BASH, BASH" />
 
@@ -174,6 +180,16 @@ Errors when opening **Configure** in App Management after re-associating or rede
 1. App Builder runtime is using a different `AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` than the key that was used when merchants originally saved those secrets.
 
 1. Restore `AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` to the default value from the first installation. Align local `.env` with whatever is configured for the deployed runtime so ciphertext and key are paired.
+
+### Encryption key has not been given (writing password fields)
+
+Calling `setConfiguration` to write a `password` field without passing `encryptionKey` in the options throws:
+
+```text
+Encryption key has not been given
+```
+
+Pass `encryptionKey: params.AIO_COMMERCE_CONFIG_ENCRYPTION_KEY` whenever you call `setConfiguration` to write a `password` field.
 
 ### Generate an encryption key
 

--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -43,6 +43,7 @@
             - [Admin UI SDK](/app-management/installation/admin-ui-sdk.md)
             - [Customize](/app-management/installation/customize.md)
     - [Build and deploy](/app-management/build-deploy.md)
+    - [App Management helpers](/app-management/helpers.md)
     - [Purchase Approval reference app](/app-management/purchase-approval-app.md)
     - [Working with AI](/app-management/working-with-ai.md)
     - [Troubleshooting](/app-management/troubleshooting.md)


### PR DESCRIPTION
## Summary

Aligns the App Management documentation with the last public `aio-commerce-sdk` release. Every SDK claim was verified against the released package tags (not the working tree, which carries unreleased commits).

### Corrections
- Business-config field types (adds `boolean`), `dynamicList` minimum version (1.6.0 → 1.5.0), and `label` required vs. optional.
- Event property names (`hipaa_audit_required` / `priority`) and required fields in `installation/events.md`; `env` environment scoping documented for events and webhooks.
- Admin UI SDK prerequisites reconciled across pages (4.2.0 / PaaS 2.4.8+; SaaS is now supported).
- `pre-app-build` regeneration behavior, `installation` action conditionality, and broken / mis-destructured code samples.
- Node version standardized to 22–24.

### Additions
- New **App Management helpers** page: `getCommerceClient` / `getCommerceInstance`, `publishEvent` / `resolveIoEventCode`, and the typed error classes (available since `@adobe/aio-commerce-lib-app` 1.8.0).
- Single canonical homes for the `#app.commerce.config` alias (Build and deploy) and the TypeScript project setup (Initialize your app); consumer pages link to them.

Jira: [CEXT-6577](https://jira.corp.adobe.com/browse/CEXT-6577)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
